### PR TITLE
Add comparison for merged PRs with no retest to total merged PRs

### DIFF
--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -46,9 +46,9 @@ const (
 	MergeQueueLengthBadgeName  = "avg merge queue length"
 	RetestsToMergeBadgeName    = "retests to merge"
 	MergedPRsBadgeName         = "merged PRs"
-	MergedPRsNoRetestBadgeName = "Merged PRs with 0 retest"
+	MergedPRsNoRetestBadgeName = "Merged PRs with 0 retest vs. Merged PRs"
 	BadgeDataFormat            = "%.2f ± std %.2f"
-	NoRetestBadgeDataFormat    = "%.0f"
+	NoRetestBadgeDataFormat    = "%.0f / %.0f"
 
 	AvgMergeQueueLengthMetricName = "cihealth_avg_merge_queue_lenght_total"
 	AvgTimeToMergeMetricName      = "cihealth_avg_time_to_merge_days"

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -212,6 +212,7 @@ func (h *Handler) mergedPRsNoRetestProcessor(results *types.Results) (*types.Res
 
 	}
 	dataItem.NoRetest = float64(len(dataItem.DataPoints))
+	dataItem.Number = float64(len(retestsToMerge))
 	results.Data[constants.MergedPRsNoRetest] = dataItem
 
 	return results, nil

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -212,6 +212,7 @@ type DataPoint struct {
 type RunningAverageDataItem struct {
 	Avg        float64
 	Std        float64
+	Number     float64
 	NoRetest   float64
 	DataPoints []DataPoint
 }
@@ -221,7 +222,7 @@ func (d *RunningAverageDataItem) String() string {
 }
 
 func (d *RunningAverageDataItem) SimpleBadgeString() string {
-	return fmt.Sprintf(constants.NoRetestBadgeDataFormat, d.NoRetest)
+	return fmt.Sprintf(constants.NoRetestBadgeDataFormat, d.NoRetest, d.Number)
 }
 
 // Results represents the data obtained from GitHub. It includes the source repo from which


### PR DESCRIPTION
This gives the user a better understanding of the amount of PRs requiring retest vs the number of PRs that did not.

This produces the following badge that will be displayed in the README.md
![merged-prs-no-retest](https://user-images.githubusercontent.com/21010464/235108214-533198fd-e793-4c45-a483-999c433a8d8e.svg)


/cc @dhiller @xpivarc 