### PR TITLE
Use Create rather than OpenFile when writing the badges

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -136,7 +136,7 @@ func (b *Handler) writeBadge(name, filePath string, data types.RunningAverageDat
 		color = NoRetestBadgeColor(data.NoRetest, levels)
 	}
 
-	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This will prevent write errors being carried through to later versions of badges as currently seen with the no retest to merge badge

/cc @enp0s3 @dhiller 