### PR TITLE
Update no retest badge colour to be relative to total merged PRs

### DIFF
--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -29,8 +29,8 @@ const (
 	DefaultRetestsToMergeRedLevel       = 6.0
 	DefaultMergedPRsYellowLevel         = 10.0
 	DefaultMergedPRsRedLevel            = 7.0
-	DefaultMergedPRsNoRetestYellowLevel = 5.0
-	DefaultMergedPRsNoRetestRedLevel    = 0.0
+	DefaultMergedPRsNoRetestYellowLevel = 0.5
+	DefaultMergedPRsNoRetestRedLevel    = 0.25
 	DefaultBatchStartDate               = "2019-05-06"
 
 	TimeToMergeBadgeFileName       = "time-to-merge.svg"

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -133,7 +133,7 @@ func (b *Handler) writeBadges(results *types.Results) error {
 func (b *Handler) writeBadge(name, filePath string, data types.RunningAverageDataItem, levels *Levels) error {
 	color := BadgeColor(data.Avg, levels)
 	if name == constants.MergedPRsNoRetestBadgeName {
-		color = NoRetestBadgeColor(data.NoRetest, levels)
+		color = NoRetestBadgeColor(data.NoRetest, data.Number, levels)
 	}
 
 	f, err := os.Create(filePath)
@@ -170,11 +170,19 @@ func BadgeColor(value float64, levels *Levels) badge.Color {
 
 	return color
 }
-func NoRetestBadgeColor(value float64, levels *Levels) badge.Color {
+func NoRetestBadgeColor(value float64, mergedPRs float64, levels *Levels) badge.Color {
 	var color badge.Color
-	if value > levels.Yellow {
+	var percentVal float64
+	if value == 0 {
+		percentVal = 0
+	} else if mergedPRs == 0 {
+		percentVal = 0
+	} else {
+		percentVal = value / mergedPRs
+	}
+	if percentVal > levels.Yellow {
 		color = badge.ColorGreen
-	} else if value <= levels.Yellow && value > levels.Red {
+	} else if percentVal <= levels.Yellow && percentVal > levels.Red {
 		color = badge.ColorYellow
 	} else {
 		color = badge.ColorRed


### PR DESCRIPTION
It makes more sense to have the badge colour based on the PRs merged
with no retest relative to the total merged PRs.

- Green badge: greater than half (0.5) of the total merged PRs were did not require a retest
- Yellow badge: greater than a quarter (0.25) but less than half of total merged PRs did not require a retest
- Red badge: less than a quarter of total merged PRs did not require a retest

/cc @enp0s3 @dhiller 