### PR TITLE
Skip phase plugin comments when counting the number of retests required

### DIFF
--- a/pkg/chatops/main.go
+++ b/pkg/chatops/main.go
@@ -53,9 +53,14 @@ func (co *Handler) RetestsToMerge(startDate, endDate time.Time) (map[types.PR]in
 // after the last commit or force push.
 func RetestComments(pr *types.ChatopsPullRequestFragment) int {
 	var total int
+	const phase2Intro = "Required labels detected, running phase 2 presubmits:"
+
 	lastPush := determineLastPush(pr)
 
 	for _, timelineItem := range pr.TimelineItems.Nodes {
+		if strings.Contains(timelineItem.BodyText, phase2Intro) {
+			continue
+		}
 		if isRetestCommentAfterLastPush(timelineItem, lastPush) {
 			total += 1
 		}


### PR DESCRIPTION
The phase plugin adds a comment[1] to PRs that are lgtm + approve - this comment triggers the jobs that are required before merge but not run against every change (phase 2). Currently this is counted as a retest which is not valid- and it should be skipped.

[1] https://github.com/kubevirt/project-infra/blob/d4470b4eda1df31056239b21a466faf49f3f8852/external-plugins/phased/plugin/handler/handler.go#L21

/cc @xpivarc  @dhiller 