### PR TITLE
badges: Raise limits for PRs merged with 0 retest

### DIFF
--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -29,8 +29,8 @@ const (
 	DefaultRetestsToMergeRedLevel       = 6.0
 	DefaultMergedPRsYellowLevel         = 10.0
 	DefaultMergedPRsRedLevel            = 7.0
-	DefaultMergedPRsNoRetestYellowLevel = 0.5
-	DefaultMergedPRsNoRetestRedLevel    = 0.25
+	DefaultMergedPRsNoRetestYellowLevel = 0.75
+	DefaultMergedPRsNoRetestRedLevel    = 0.5
 	DefaultBatchStartDate               = "2019-05-06"
 
 	TimeToMergeBadgeFileName       = "time-to-merge.svg"


### PR DESCRIPTION
**What this PR does / why we need it**:

The merged PRs with 0 retest has been regularly over 50% of total merged PRs. This currently marks the badge as green.

Lets raise the bar for a green badge to 75% and over. While below 50% will now mark the badge as red.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
