### PR TITLE
sig,badges: Add total number of jobs run per SIG to each SIG badge

### DIFF
--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -33,7 +33,7 @@ const (
 	DefaultMergedPRsNoRetestYellowLevel = 0.75
 	DefaultMergedPRsNoRetestRedLevel    = 0.5
 	DefaultSIGRetestYellowLevel         = 1
-	DefaultSIGRetestRedLevel            = 20
+	DefaultSIGRetestRedLevel            = 15
 	DefaultBatchStartDate               = "2019-05-06"
 
 	TimeToMergeBadgeFileName       = "time-to-merge.svg"

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -191,19 +191,24 @@ func (b *Handler) writeBadge(name, filePath string, data types.RunningAverageDat
 
 func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningAverageDataItem, levels *Levels) error {
 	var value float64
+	var total float64
 
 	switch name {
 	case constants.SIGComputeRetestBadgeName:
 		value = data.SIGComputeRetest
+		total = data.SIGComputeTotal
 	case constants.SIGNetworkRetestBadgeName:
 		value = data.SIGNetworkRetest
+		total = data.SIGNetworkTotal
 	case constants.SIGStorageRetestBadgeName:
 		value = data.SIGStorageRetest
+		total = data.SIGStorageTotal
 	case constants.SIGOperatorRetestBadgeName:
 		value = data.SIGOperatorRetest
+		total = data.SIGOperatorTotal
 	}
 
-	color := BadgeColor(value, levels)
+	color := BadgeColor(((value / total) * 100), levels)
 
 	f, err := os.Create(filePath)
 	if err != nil {
@@ -211,7 +216,7 @@ func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningA
 	}
 	defer f.Close()
 
-	badgeString := fmt.Sprintf("%.0f", value)
+	badgeString := fmt.Sprintf("%.0f / %.0f", value, total)
 
 	return badge.Render(name, badgeString, color, f)
 }

--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -21,12 +21,16 @@ type job struct {
 }
 
 type SigRetests struct {
-	SigCompute      int
-	SigNetwork      int
-	SigStorage      int
-	SigOperator     int
-	FailedJobNames  []string
-	SuccessJobNames []string
+	SigComputeFailure  int
+	SigNetworkFailure  int
+	SigStorageFailure  int
+	SigOperatorFailure int
+	SigComputeSuccess  int
+	SigNetworkSuccess  int
+	SigStorageSuccess  int
+	SigOperatorSuccess int
+	FailedJobNames     []string
+	SuccessJobNames    []string
 }
 
 var prowjobs []job
@@ -165,19 +169,30 @@ func sortJobNamesOnResult(job job, sigRetests SigRetests) (jobCounts SigRetests)
 func FilterJobsPerSigs(jobs []job) (prSigRetests SigRetests) {
 	prSigRetests = SigRetests{}
 	for _, job := range jobs {
-		if job.failure {
-			switch {
-			case strings.Contains(job.jobName, "sig-compute") || strings.Contains(job.jobName, "vgpu"):
-				prSigRetests.SigCompute += 1
-
-			case strings.Contains(job.jobName, "sig-network") || strings.Contains(job.jobName, "sriov"):
-				prSigRetests.SigNetwork += 1
-
-			case strings.Contains(job.jobName, "sig-storage"):
-				prSigRetests.SigStorage += 1
-
-			case strings.Contains(job.jobName, "sig-operator"):
-				prSigRetests.SigOperator += 1
+		switch {
+		case strings.Contains(job.jobName, "sig-compute") || strings.Contains(job.jobName, "vgpu"):
+			if job.failure {
+				prSigRetests.SigComputeFailure += 1
+			} else {
+				prSigRetests.SigComputeSuccess += 1
+			}
+		case strings.Contains(job.jobName, "sig-network") || strings.Contains(job.jobName, "sriov"):
+			if job.failure {
+				prSigRetests.SigNetworkFailure += 1
+			} else {
+				prSigRetests.SigNetworkSuccess += 1
+			}
+		case strings.Contains(job.jobName, "sig-storage"):
+			if job.failure {
+				prSigRetests.SigStorageFailure += 1
+			} else {
+				prSigRetests.SigStorageSuccess += 1
+			}
+		case strings.Contains(job.jobName, "sig-operator"):
+			if job.failure {
+				prSigRetests.SigOperatorFailure += 1
+			} else {
+				prSigRetests.SigOperatorSuccess += 1
 			}
 		}
 		prSigRetests = sortJobNamesOnResult(job, prSigRetests)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -271,21 +271,25 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 	}
 
 	for _, mergedPR := range mergedPRs {
-		failuresPerSIG, err := sigretests.GetJobsPerSIG(strconv.Itoa(mergedPR.Number), "kubevirt", "kubevirt")
+		jobsPerSIG, err := sigretests.GetJobsPerSIG(strconv.Itoa(mergedPR.Number), "kubevirt", "kubevirt")
 		if err != nil {
 			return results, err
 		}
-		dataItem.SIGComputeRetest = dataItem.SIGComputeRetest + float64(failuresPerSIG.SigCompute)
-		dataItem.SIGNetworkRetest = dataItem.SIGNetworkRetest + float64(failuresPerSIG.SigNetwork)
-		dataItem.SIGStorageRetest = dataItem.SIGStorageRetest + float64(failuresPerSIG.SigStorage)
-		dataItem.SIGOperatorRetest = dataItem.SIGOperatorRetest + float64(failuresPerSIG.SigOperator)
+		dataItem.SIGComputeRetest = dataItem.SIGComputeRetest + float64(jobsPerSIG.SigComputeFailure)
+		dataItem.SIGNetworkRetest = dataItem.SIGNetworkRetest + float64(jobsPerSIG.SigNetworkFailure)
+		dataItem.SIGStorageRetest = dataItem.SIGStorageRetest + float64(jobsPerSIG.SigStorageFailure)
+		dataItem.SIGOperatorRetest = dataItem.SIGOperatorRetest + float64(jobsPerSIG.SigOperatorFailure)
+		dataItem.SIGComputeTotal = dataItem.SIGComputeTotal + float64(jobsPerSIG.SigComputeFailure) + float64(jobsPerSIG.SigComputeSuccess)
+		dataItem.SIGNetworkTotal = dataItem.SIGNetworkTotal + float64(jobsPerSIG.SigNetworkFailure) + float64(jobsPerSIG.SigNetworkSuccess)
+		dataItem.SIGStorageTotal = dataItem.SIGStorageTotal + float64(jobsPerSIG.SigStorageFailure) + float64(jobsPerSIG.SigStorageSuccess)
+		dataItem.SIGOperatorTotal = dataItem.SIGOperatorTotal + float64(jobsPerSIG.SigOperatorFailure) + float64(jobsPerSIG.SigOperatorSuccess)
 		dataItem.DataPoints = append(dataItem.DataPoints,
 			types.DataPoint{
-				Value: float64(len(failuresPerSIG.FailedJobNames)),
+				Value: float64(len(jobsPerSIG.FailedJobNames)),
 				PRs:   []types.PR{mergedPR},
 			})
-		failedJobNames = slices.Concat(failedJobNames, failuresPerSIG.FailedJobNames)
-		successJobNames = slices.Concat(successJobNames, failuresPerSIG.SuccessJobNames)
+		failedJobNames = slices.Concat(failedJobNames, jobsPerSIG.FailedJobNames)
+		successJobNames = slices.Concat(successJobNames, jobsPerSIG.SuccessJobNames)
 	}
 	sortedFailedJobs := types.SortByMostFailed(countFailedJobs(failedJobNames))
 	for i, job := range sortedFailedJobs {

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -245,6 +245,10 @@ type RunningAverageDataItem struct {
 	SIGStorageRetest     float64
 	SIGNetworkRetest     float64
 	SIGOperatorRetest    float64
+	SIGComputeTotal      float64
+	SIGStorageTotal      float64
+	SIGNetworkTotal      float64
+	SIGOperatorTotal     float64
 	FailedJobLeaderBoard FailedJobs
 	DataPoints           []DataPoint
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The number of failed runs per SIG does not give a clear picture on its own without the total number of job runs per SIG as each SIG has a different number of lanes that runs against each PR.

This includes the total number of jobs run per SIG in each SIG badge and sets the badge colour to reflect the percentage of failed jobs out of total jobs run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66 

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
