### PR TITLE
e2e,failures: Include links to the failed prow jobs for each test lane in the failure board

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,4 +23,4 @@ jobs:
       run: |
         echo -n $GITHUB_TOKEN > $(pwd)/token
 
-        bazelisk test ... --action_env GITHUB_TOKEN_PATH=$(pwd)/token
+        bazelisk test ... --action_env GITHUB_TOKEN_PATH=$(pwd)/token --test_timeout=600

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Top failed lanes:
 
 ![failedjob10](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/failedjob10.svg)
 
+The links to each of these failed jobs can be found in the [latest execution data](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/results.json)
+under the SIGRetests section
+
 ## Historical data evolution
 
 These plots will be updated every week.

--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -30,6 +30,7 @@ type SigRetests struct {
 	SigStorageSuccess  int
 	SigOperatorSuccess int
 	FailedJobNames     []string
+	FailedJobURLs      []string
 	SuccessJobNames    []string
 }
 
@@ -55,7 +56,7 @@ func filterJobs(node *html.Node) (jobs []job) {
 				for _, href := range node.FirstChild.Attr {
 					if strings.Contains(href.Val, "e2e") {
 						e2eJob.failure = true
-						e2eJob.buildURL = href.Val
+						e2eJob.buildURL = fmt.Sprintf("https://prow.ci.kubevirt.io/%s", href.Val)
 						buildLogUrl := strings.Split(href.Val, "/")
 						e2eJob.jobName = buildLogUrl[len(buildLogUrl)-2]
 						e2eJob.buildNumber = buildLogUrl[len(buildLogUrl)-1]
@@ -160,6 +161,7 @@ func getJobsForLatestCommit(org string, repo string, prNumber string) (jobsLastC
 func sortJobNamesOnResult(job job, sigRetests SigRetests) (jobCounts SigRetests) {
 	if job.failure == true {
 		sigRetests.FailedJobNames = append(sigRetests.FailedJobNames, job.jobName)
+		sigRetests.FailedJobURLs = append(sigRetests.FailedJobURLs, job.buildURL)
 	} else {
 		sigRetests.SuccessJobNames = append(sigRetests.SuccessJobNames, job.jobName)
 	}

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -215,6 +215,7 @@ type FailedJob struct {
 	JobName      string
 	FailureCount int
 	SuccesCount  int
+	FailureURLs  []string
 }
 
 type FailedJobs []FailedJob
@@ -227,7 +228,7 @@ func SortByMostFailed(countFailedJobs map[string]int) FailedJobs {
 	fl := make(FailedJobs, len(countFailedJobs))
 	i := 0
 	for j, f := range countFailedJobs {
-		fl[i] = FailedJob{j, f, 0}
+		fl[i] = FailedJob{j, f, 0, nil}
 		i++
 	}
 	sort.Sort(sort.Reverse(fl))


### PR DESCRIPTION
**What this PR does / why we need it**:

Having the failed job links included makes these metrics more actionable
as the relevant SIGs can quickly check the failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
