### PR TITLE
Update time to merge badge from days to hours

### DIFF
--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -49,7 +49,7 @@ const (
 	PlotFileName                   = "plot.png"
 	MetricsFileName                = "metrics"
 
-	TimeToMergeBadgeName       = "days to merge"
+	TimeToMergeBadgeName       = "hours to merge"
 	MergeQueueLengthBadgeName  = "avg merge queue length"
 	RetestsToMergeBadgeName    = "retests to merge"
 	MergedPRsBadgeName         = "merged PRs"

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -184,6 +184,9 @@ func (b *Handler) writeBadge(name, filePath string, data types.RunningAverageDat
 	if name == constants.MergedPRsNoRetestBadgeName {
 		badgeString = data.SimpleBadgeString()
 	}
+	if name == constants.TimeToMergeBadgeName {
+		badgeString = fmt.Sprintf("%.2f ± std %.2f", (data.Avg * 24), (data.Std * 24))
+	}
 	err = badge.Render(name, badgeString, color, f)
 
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Thanks to improvements over the last few months the average time to merge is no longer mulitple days but now can be measured in hours.

This change only updates the badge to display the time to merge in hours rather than days.

The underlying data has not been changed as to keep the historical results and graphs consistent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
