### PR TITLE
sig,badges: Include the percentage failure rate in SIG and lane badges

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -219,7 +219,7 @@ func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningA
 	}
 	defer f.Close()
 
-	badgeString := fmt.Sprintf("%.0f / %.0f", value, total)
+	badgeString := fmt.Sprintf("%.0f / %.0f    |    %.0f%s", value, total, (value/total)*100, "%")
 
 	return badge.Render(name, badgeString, color, f)
 }
@@ -241,7 +241,10 @@ func (b *Handler) writeJobFailureBadges(data types.RunningAverageDataItem, level
 		if i < len(failedJobLeaders) {
 			job := failedJobLeaders[i-1]
 			color := BadgeColor(float64(job.FailureCount), levels)
-			badgeString := fmt.Sprintf("%.0f / %.0f", float64(job.FailureCount), float64(job.FailureCount+job.SuccesCount))
+			badgeString := fmt.Sprintf("%.0f / %.0f    |    %.0f%s",
+				float64(job.FailureCount),
+				float64(job.FailureCount+job.SuccessCount),
+				(float64(job.FailureCount)/float64(job.FailureCount+job.SuccessCount))*100, "%")
 
 			err = badge.Render(job.JobName, badgeString, color, f)
 		} else {

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -298,7 +298,7 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 	for i, job := range sortedFailedJobs {
 		for _, success := range successJobNames {
 			if job.JobName == success {
-				sortedFailedJobs[i].SuccesCount++
+				sortedFailedJobs[i].SuccessCount++
 			}
 		}
 		for _, failedJobURL := range failedJobURLs {

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -214,7 +214,7 @@ type DataPoint struct {
 type FailedJob struct {
 	JobName      string
 	FailureCount int
-	SuccesCount  int
+	SuccessCount int
 	FailureURLs  []string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the SIG and e2e lane badges only display the absolute number
of failures vs. the total number of lanes run.

Including the percentage failure rate is also useful information to stop
users from having to calculate that themselves.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
