### PR TITLE
badges: Add percentage of no retests to the No Retests badge

### DIFF
--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -59,7 +59,7 @@ const (
 	SIGOperatorRetestBadgeName = "SIG Operator"
 	SIGStorageRetestBadgeName  = "SIG Storage"
 	BadgeDataFormat            = "%.2f ± std %.2f"
-	NoRetestBadgeDataFormat    = "%.0f / %.0f"
+	NoRetestBadgeDataFormat    = "%.0f / %.0f | %.0f%s"
 
 	AvgMergeQueueLengthMetricName = "cihealth_avg_merge_queue_lenght_total"
 	AvgTimeToMergeMetricName      = "cihealth_avg_time_to_merge_days"

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -259,7 +259,7 @@ func (d *RunningAverageDataItem) String() string {
 }
 
 func (d *RunningAverageDataItem) SimpleBadgeString() string {
-	return fmt.Sprintf(constants.NoRetestBadgeDataFormat, d.NoRetest, d.Number)
+	return fmt.Sprintf(constants.NoRetestBadgeDataFormat, d.NoRetest, d.Number, (d.NoRetest/d.Number)*100, "%")
 }
 
 // Results represents the data obtained from GitHub. It includes the source repo from which


### PR DESCRIPTION
**What this PR does / why we need it**:

Rather than leaving the user calculate the percentage of No Retests - lets add it to the badge

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
