### PR TITLE
stats: Add a check and count for CI infra failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Each of these failures contribute to the number of retests that occur in CI and 
 ![sig-storage-retests](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/sig-storage-retests.svg)
 ![sig-network-retests](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/sig-network-retests.svg)
 ![sig-operator-retests](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/sig-operator-retests.svg)
+![sig-ci-retests](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/sig-ci-retests.svg)
 
 Top failed lanes:
 

--- a/pkg/constants/main.go
+++ b/pkg/constants/main.go
@@ -45,6 +45,7 @@ const (
 	SIGNetworkRetestBadgeFileName  = "sig-network-retests.svg"
 	SIGStorageRetestBadgeFileName  = "sig-storage-retests.svg"
 	SIGOperatorRetestBadgeFileName = "sig-operator-retests.svg"
+	SIGCIRetestBadgeFileName       = "sig-ci-retests.svg"
 	JSONResultsFileName            = "results.json"
 	PlotFileName                   = "plot.png"
 	MetricsFileName                = "metrics"
@@ -58,6 +59,7 @@ const (
 	SIGNetworkRetestBadgeName  = "SIG Network"
 	SIGOperatorRetestBadgeName = "SIG Operator"
 	SIGStorageRetestBadgeName  = "SIG Storage"
+	SIGCIRetestBadgeName       = "SIG CI"
 	BadgeDataFormat            = "%.2f ± std %.2f"
 	NoRetestBadgeDataFormat    = "%.0f / %.0f | %.0f%s"
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -159,6 +159,13 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		b.options.SIGRetestsLevels,
 	)
 
+	err = b.writeSIGRetestBadge(
+		constants.SIGCIRetestBadgeName,
+		filepath.Join(basePath, constants.SIGCIRetestBadgeFileName),
+		results.Data[constants.SIGRetests],
+		b.options.SIGRetestsLevels,
+	)
+
 	err = b.writeJobFailureBadges(
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
@@ -209,6 +216,9 @@ func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningA
 	case constants.SIGOperatorRetestBadgeName:
 		value = data.SIGOperatorRetest
 		total = data.SIGOperatorTotal
+	case constants.SIGCIRetestBadgeName:
+		value = data.SIGCIRetest
+		total = data.SIGCITotal
 	}
 
 	color := BadgeColor(((value / total) * 100), levels)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -281,6 +281,7 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 		dataItem.SIGNetworkRetest = dataItem.SIGNetworkRetest + float64(jobsPerSIG.SigNetworkFailure)
 		dataItem.SIGStorageRetest = dataItem.SIGStorageRetest + float64(jobsPerSIG.SigStorageFailure)
 		dataItem.SIGOperatorRetest = dataItem.SIGOperatorRetest + float64(jobsPerSIG.SigOperatorFailure)
+		dataItem.SIGCIRetest = dataItem.SIGCIRetest + float64(jobsPerSIG.SigCIFailure)
 		dataItem.SIGComputeTotal = dataItem.SIGComputeTotal + float64(jobsPerSIG.SigComputeFailure) + float64(jobsPerSIG.SigComputeSuccess)
 		dataItem.SIGNetworkTotal = dataItem.SIGNetworkTotal + float64(jobsPerSIG.SigNetworkFailure) + float64(jobsPerSIG.SigNetworkSuccess)
 		dataItem.SIGStorageTotal = dataItem.SIGStorageTotal + float64(jobsPerSIG.SigStorageFailure) + float64(jobsPerSIG.SigStorageSuccess)
@@ -294,6 +295,7 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 		successJobNames = slices.Concat(successJobNames, jobsPerSIG.SuccessJobNames)
 		failedJobURLs = slices.Concat(failedJobURLs, jobsPerSIG.FailedJobURLs)
 	}
+	dataItem.SIGCITotal = dataItem.SIGComputeTotal + dataItem.SIGStorageTotal + dataItem.SIGNetworkTotal + dataItem.SIGOperatorTotal + dataItem.SIGCIRetest
 	sortedFailedJobs := types.SortByMostFailed(countFailedJobs(failedJobNames))
 	for i, job := range sortedFailedJobs {
 		for _, success := range successJobNames {

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -246,10 +246,12 @@ type RunningAverageDataItem struct {
 	SIGStorageRetest     float64
 	SIGNetworkRetest     float64
 	SIGOperatorRetest    float64
+	SIGCIRetest          float64
 	SIGComputeTotal      float64
 	SIGStorageTotal      float64
 	SIGNetworkTotal      float64
 	SIGOperatorTotal     float64
+	SIGCITotal           float64
 	FailedJobLeaderBoard FailedJobs
 	DataPoints           []DataPoint
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This check looks for any failed e2e lanes that did not get as far as
running the tests and creating a junit.functext.xml. This is a good
indicator that a failure has occurred in kubevirtci.

Creates a bade like the following:
![sig-ci-retests](https://github.com/user-attachments/assets/39e6d93f-43a5-4c92-9f34-bb8d3cb4a1f8)



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
