### PR TITLE
fix,pr-history: add retry to http get

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ data from the previous 7 days since the execution time.
 
 ### kubevirt/kubevirt
 
-![avg-merge-queue-lenght](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/merge-queue-length.svg)
+![avg-merge-queue-length](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/merge-queue-length.svg)
 ![avg-time-to-merge](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/time-to-merge.svg)
 ![avg-retests-to-merge](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/retests-to-merge.svg)
 ![merged-prs-with-no-retest](https://kubevirt.io/ci-health/output/kubevirt/kubevirt/merged-prs-no-retest.svg)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1677,6 +1677,13 @@ go_repository(
     version = "v0.19.0",
 )
 
+go_repository(
+    name = "com_github_avast_retry_go",
+    importpath = "github.com/avast/retry-go",
+    sum = "h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=",
+    version = "v3.0.0+incompatible",
+)
+
 # gazelle:repository_macro deps.bzl%go_dependencies
 go_dependencies()
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kubevirt/ci-health
 go 1.22
 
 require (
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/narqo/go-badge v0.0.0-20221212191103-ba83bed45a1a
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.10

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zum
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af h1:wVe6/Ea46ZMeNkQjjBW6xcqyQA/j5e0D6GytH95g0gQ=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/pkg/sigretests/BUILD.bazel
+++ b/pkg/sigretests/BUILD.bazel
@@ -5,5 +5,9 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/kubevirt/ci-health/pkg/sigretests",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_net//html"],
+    deps = [
+        "@com_github_avast_retry_go//:retry-go",
+        "@com_github_sirupsen_logrus//:logrus",
+        "@org_golang_x_net//html",
+    ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

pr-history gives a 504 if PRs have a long history [1] .

To counter this we add a retry to the http get calling the pr-history
page.

[1]: kubernetes/test-infra#31850

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @avlitman @brianmcarey 