### PR TITLE
actions: Use debian based golang container image that has git installed

### DIFF
--- a/.github/workflows/badges-update.yaml
+++ b/.github/workflows/badges-update.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   badge-update:
     runs-on: ubuntu-latest
-    container: docker.io/golang:1.22-alpine
+    container: docker.io/golang:1.22
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/historical-update.yaml
+++ b/.github/workflows/historical-update.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   badge-update:
     runs-on: ubuntu-latest
-    container: docker.io/golang:1.22-alpine
+    container: docker.io/golang:1.22
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Workflows are failing because the alpine golang image does not have git installed - switch to using the debian based image which does have git installed. 

```
podman run docker.io/golang:1.22-alpine git --version
Error: preparing container ae554b180e0ef51022e492ed4a6543a73900ffde8a5a3083f1bf6ce5bb1793a5 for attach: crun: executable file `git` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found

podman run docker.io/golang:1.22 git --version
git version 2.39.5
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #79 

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
