### PR TITLE
retests: Remove check for /test from retest count

### DIFF
--- a/pkg/chatops/chatops_test.go
+++ b/pkg/chatops/chatops_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	testComment   = "/test"
 	retestComment = "/retest"
 )
 
@@ -475,33 +474,6 @@ even more lines
 				},
 			},
 			1),
-		table.Entry("Handles both retest commands formats",
-			&types.ChatopsPullRequestFragment{
-				TimelineItems: types.TimelineItems{
-					Nodes: []types.TimelineItem{
-						{
-							PullRequestCommitFragment: types.PullRequestCommitFragment{
-								Commit: types.Commit{
-									CommittedDate: queryDate.AddDate(0, 0, -3),
-								},
-							},
-						},
-						{
-							IssueCommentFragment: types.IssueCommentFragment{
-								CreatedAt: queryDate.AddDate(0, 0, -2),
-								BodyText:  "/test my-test",
-							},
-						},
-						{
-							IssueCommentFragment: types.IssueCommentFragment{
-								CreatedAt: queryDate.AddDate(0, 0, -1),
-								BodyText:  "/retest",
-							},
-						},
-					},
-				},
-			},
-			2),
 		table.Entry("One retest call after last HeadRef force push, previous after commit/BaseRef force push are ignored",
 			&types.ChatopsPullRequestFragment{
 				TimelineItems: types.TimelineItems{

--- a/pkg/chatops/main.go
+++ b/pkg/chatops/main.go
@@ -103,6 +103,5 @@ func isBaseRefForcePush(timelineItem types.TimelineItem) bool {
 func isRetestCommentAfterLastPush(timelineItem types.TimelineItem, lastPush time.Time) bool {
 	return timelineItem.IssueCommentFragment != types.IssueCommentFragment{} &&
 		timelineItem.IssueCommentFragment.CreatedAt.After(lastPush) &&
-		(strings.HasPrefix(timelineItem.IssueCommentFragment.BodyText, "/retest") ||
-			strings.HasPrefix(timelineItem.IssueCommentFragment.BodyText, "/test"))
+		(strings.HasPrefix(timelineItem.IssueCommentFragment.BodyText, "/retest"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There are occasions where contributors want to test some lanes multiple times against a PR to ensure that the PR does not introduce an instability.

In these cases, the contributors use /test to trigger these lanes. This muddies the PRs merged with zero retest metric as these are not retests but are counted as such. It is also used to trigger test lanes for contributors who are not yet kubevirt members and have permissions to run CI.

For example in these two recent PRs:
https://github.com/kubevirt/kubevirt/pull/14880
https://github.com/kubevirt/kubevirt/pull/14832

Remove the check for /test as this causes PRs with 0 retest to be missed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
