### PR TITLE
feat(sig-ci): failure url retrieval

### DIFF
--- a/hack/show-ci-failure-jobs.sh
+++ b/hack/show-ci-failure-jobs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+#
+
+set -euo pipefail
+
+function usage() {
+    cat <<EOF
+usage: $0
+
+    fetches URLs for the CI failure runs from the data of the latest run -
+    covering last 7 days.
+EOF
+}
+
+if [ "$#" -gt 0 ]; then
+    if [[ "$1" == -h ]] || [[ "$1" == --help ]]; then
+        usage
+        exit 0
+    else
+        usage
+        exit 1
+    fi
+fi
+
+for url in $(jq -r '.Data.SIGRetests.FailedJobLeaderBoard[].FailureURLs | flatten[]' ./output/kubevirt/kubevirt/results.json); do
+    if ! curl -s --head --fail "$(echo "$url" | sed -re 's#^https://prow.ci.kubevirt.io//view/gs/(.*)#https://storage.googleapis.com/\1/artifacts/junit.functest.xml#g')" -o /dev/null; then
+        echo "$url"
+    fi
+done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds a script that retrieves sig-ci failures.

The script fetches the urls from the latest failed jobs from the leaderboard and checks for presence of junit.xml file in artifacts. If the latter is not present this is considered a failure counting towards sig-ci.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey 