### PR TITLE
feat(stats): filter unsupported release branches

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -38,7 +39,7 @@ func Run(o *types.Options) (*types.Results, error) {
 
 	switch o.Action {
 	case types.StatsAction:
-		return statsRun(o, mqHandler, coHandler)
+		return statsRun(o, mqHandler, coHandler, ghClient)
 	case types.BatchAction:
 		return batchRun(o, mqHandler, coHandler)
 	default:
@@ -46,13 +47,19 @@ func Run(o *types.Options) (*types.Results, error) {
 	}
 }
 
-func statsRun(o *types.Options, mqHandler *mergequeue.Handler, coHandler *chatops.Handler) (*types.Results, error) {
+func statsRun(o *types.Options, mqHandler *mergequeue.Handler, coHandler *chatops.Handler, ghClient *gh.Client) (*types.Results, error) {
+	supportedBranches, err := ghClient.GetSupportedBranches(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
 	options := &stats.HandlerOptions{
-		Mq:       mqHandler,
-		Co:       coHandler,
-		Source:   o.Source,
-		DataDays: o.DataDays,
-		EndDate:  time.Now(),
+		Mq:                mqHandler,
+		Co:                coHandler,
+		Source:            o.Source,
+		DataDays:          o.DataDays,
+		EndDate:           time.Now(),
+		SupportedBranches: supportedBranches,
 
 		TargetMetrics: []types.Metric{
 			types.MergeQueueLengthMetric,

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -19,32 +19,35 @@ import (
 type statsProcessor func(*types.Results) (*types.Results, error)
 
 type HandlerOptions struct {
-	Mq       *mergequeue.Handler
-	Co       *chatops.Handler
-	Source   string
-	EndDate  time.Time
-	DataDays int
+	Mq                *mergequeue.Handler
+	Co                *chatops.Handler
+	Source            string
+	EndDate           time.Time
+	DataDays          int
+	SupportedBranches []string
 
 	TargetMetrics []types.Metric
 }
 
 type Handler struct {
-	mq            *mergequeue.Handler
-	co            *chatops.Handler
-	source        string
-	endDate       time.Time
-	dataDays      int
-	targetMetrics []types.Metric
+	mq                *mergequeue.Handler
+	co                *chatops.Handler
+	source            string
+	endDate           time.Time
+	dataDays          int
+	supportedBranches []string
+	targetMetrics     []types.Metric
 }
 
 func NewHandler(ho *HandlerOptions) *Handler {
 	return &Handler{
-		mq:            ho.Mq,
-		co:            ho.Co,
-		source:        ho.Source,
-		endDate:       ho.EndDate,
-		dataDays:      ho.DataDays,
-		targetMetrics: ho.TargetMetrics,
+		mq:                ho.Mq,
+		co:                ho.Co,
+		source:            ho.Source,
+		endDate:           ho.EndDate,
+		dataDays:          ho.DataDays,
+		supportedBranches: ho.SupportedBranches,
+		targetMetrics:     ho.TargetMetrics,
 	}
 }
 
@@ -276,7 +279,7 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 	}
 
 	for _, mergedPR := range mergedPRs {
-		jobsPerSIG, err := sigretests.GetJobsPerSIG(strconv.Itoa(mergedPR.Number), "kubevirt", "kubevirt")
+		jobsPerSIG, err := sigretests.GetJobsPerSIG(strconv.Itoa(mergedPR.Number), "kubevirt", "kubevirt", h.supportedBranches)
 		if err != nil {
 			return results, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

> # Platform Support
> Every KubeVirt release is
> 1. targeted towards and life-time coupled with the most recent Kubernetes release
> 2. throughout it's life-time the release is validated against the Kubernetes release
> in the [support period](https://kubernetes.io/releases/patch-releases/#support-period) at the time of GA of the KubeVirt release
([source](https://github.com/kubevirt/kubevirt/blob/b3013968fb122bf3d912d8279aa4f77f6d18d00b/docs/release.md?plain=1#L27))

Also the k8s-support matrix shows the EOL'd versions: https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md

This effectively means that the KubeVirt community will only actively support the three latest release branches, since only these target supported Kubernetes versions - all other branches are supported at best-effort.

Therefore we should calculate the metrics only considering the supported branches.

This change filters unsupported release branches from the metric calculation process.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey @cuiyingd