### PR TITLE
sig,faiures: Add script to calculate the average SIG failure rates over a given period of time

### DIFF
--- a/hack/sig-failure-rate-average.sh
+++ b/hack/sig-failure-rate-average.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+#
+
+set -e
+
+DAYS=${1:-90}
+INTERVAL_DAYS=7
+
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
+    echo "Error: Number of days must be a positive integer"
+    echo "Usage: $0 [days]"
+    exit 1
+fi
+
+echo "Collecting SIG failure rate data over $DAYS days with $INTERVAL_DAYS day intervals..." >&2
+
+TEMP_FILE=$(mktemp)
+trap "rm -f $TEMP_FILE" EXIT
+
+# Create CSV header
+echo "Date,SIG,Retests,Total,FailureRate" > "$TEMP_FILE"
+
+NUM_SAMPLES=$((DAYS / INTERVAL_DAYS))
+
+# Get list of commits to sample from
+COMMITS=$(git log --oneline --format="%h %cd %s" --date=short --since="${DAYS} days ago" | grep -i "badges updated" | awk '{print $1 "," $2}')
+
+if [ -z "$COMMITS" ]; then
+    echo "Error: No 'Badges updated' commits found in the last $DAYS days" >&2
+    echo "Available commits:" >&2
+    git log --oneline --since="${DAYS} days ago" | head -5 >&2
+    exit 1
+fi
+
+# Sample commits at intervals
+COMMIT_ARRAY=()
+while IFS= read -r line; do
+    COMMIT_ARRAY+=("$line")
+done <<< "$COMMITS"
+
+TOTAL_COMMITS=${#COMMIT_ARRAY[@]}
+echo "Found $TOTAL_COMMITS badge update commits" >&2
+
+for ((i = 0; i < NUM_SAMPLES; i++)); do
+    INDEX=$((i * INTERVAL_DAYS * TOTAL_COMMITS / DAYS))
+    if [ "$INDEX" -ge "$TOTAL_COMMITS" ]; then
+        INDEX=$((TOTAL_COMMITS - 1))
+    fi
+
+    COMMIT_INFO=${COMMIT_ARRAY[$INDEX]}
+    COMMIT_HASH=$(echo "$COMMIT_INFO" | cut -d',' -f1)
+    COMMIT_DATE=$(echo "$COMMIT_INFO" | cut -d',' -f2)
+
+    echo "Processing commit $COMMIT_HASH from $COMMIT_DATE..." >&2
+
+    # Extract SIG data from this commit
+    RESULTS_JSON=$(git show "$COMMIT_HASH:output/kubevirt/kubevirt/results.json" 2>/dev/null || echo "{}")
+
+    if [ "$RESULTS_JSON" = "{}" ]; then
+        echo "Warning: Could not find results.json in commit $COMMIT_HASH, skipping..." >&2
+        continue
+    fi
+
+    # Extract SIG retest data
+    SIG_COMPUTE_RETESTS=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGComputeRetest // 0')
+    SIG_COMPUTE_TOTAL=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGComputeTotal // 0')
+
+    SIG_STORAGE_RETESTS=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGStorageRetest // 0')
+    SIG_STORAGE_TOTAL=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGStorageTotal // 0')
+
+    SIG_NETWORK_RETESTS=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGNetworkRetest // 0')
+    SIG_NETWORK_TOTAL=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGNetworkTotal // 0')
+
+    SIG_OPERATOR_RETESTS=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGOperatorRetest // 0')
+    SIG_OPERATOR_TOTAL=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGOperatorTotal // 0')
+
+    SIG_CI_RETESTS=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGCIRetest // 0')
+    SIG_CI_TOTAL=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGCITotal // 0')
+
+    SIG_MONITORING_RETESTS=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGMonitoringRetest // 0')
+    SIG_MONITORING_TOTAL=$(echo "$RESULTS_JSON" | jq -r '.Data.SIGRetests.SIGMonitoringTotal // 0')
+
+    # Calculate failure rates
+    for SIG in "Compute" "Operator" "Storage" "Network" "CI" "Monitoring"; do
+        case $SIG in
+            "Compute")
+                RETESTS=$SIG_COMPUTE_RETESTS
+                TOTAL=$SIG_COMPUTE_TOTAL
+                ;;
+            "Storage")
+                RETESTS=$SIG_STORAGE_RETESTS
+                TOTAL=$SIG_STORAGE_TOTAL
+                ;;
+            "Network")
+                RETESTS=$SIG_NETWORK_RETESTS
+                TOTAL=$SIG_NETWORK_TOTAL
+                ;;
+            "Operator")
+                RETESTS=$SIG_OPERATOR_RETESTS
+                TOTAL=$SIG_OPERATOR_TOTAL
+                ;;
+            "CI")
+                RETESTS=$SIG_CI_RETESTS
+                TOTAL=$SIG_CI_TOTAL
+                ;;
+            "Monitoring")
+                RETESTS=$SIG_MONITORING_RETESTS
+                TOTAL=$SIG_MONITORING_TOTAL
+                ;;
+        esac
+
+        if [ "$TOTAL" -gt 0 ]; then
+            FAILURE_RATE=$(echo "scale=4; $RETESTS / $TOTAL" | bc)
+        else
+            FAILURE_RATE="0.0000"
+        fi
+
+        echo "$COMMIT_DATE,SIG-$SIG,$RETESTS,$TOTAL,$FAILURE_RATE" >> "$TEMP_FILE"
+    done
+done
+
+
+echo ""
+echo "Average Failure Rates by SIG over $DAYS days:"
+echo "============================================="
+
+for SIG in "Compute" "Operator" "Storage" "Network" "CI" "Monitoring"; do
+    AVG_RATE=$(awk -F',' -v sig="SIG-$SIG" '$2 == sig { sum += $5; count++ } END { if (count > 0) print sum/count; else print 0 }' "$TEMP_FILE")
+    TOTAL_RETESTS=$(awk -F',' -v sig="SIG-$SIG" '$2 == sig { sum += $3 } END { print sum+0 }' "$TEMP_FILE")
+    TOTAL_TESTS=$(awk -F',' -v sig="SIG-$SIG" '$2 == sig { sum += $4 } END { print sum+0 }' "$TEMP_FILE")
+
+    printf "%-12s: %.4f%% (%d retests / %d total tests)\n" "$SIG" "$(echo "$AVG_RATE * 100" | bc)" "$TOTAL_RETESTS" "$TOTAL_TESTS"
+done


### PR DESCRIPTION


**What this PR does / why we need it**:

While the 7 days average is useful for getting a near live picture of how the CI is performing. It can be sometimes useful to see how the SIGs have performed over a number of months.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
