### PR TITLE
sig,badges: Add handling for when there are zero lanes run for a SIG

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -266,7 +266,14 @@ func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningA
 		total = data.SIGMonitoringTotal
 	}
 
-	color := BadgeColor(((value / total) * 100), levels)
+	var percentage float64
+	if total == 0 {
+		percentage = 0.00
+	} else {
+		percentage = (value / total) * 100
+	}
+
+	color := BadgeColor(percentage, levels)
 
 	f, err := os.Create(filePath)
 	if err != nil {
@@ -274,7 +281,7 @@ func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningA
 	}
 	defer f.Close()
 
-	badgeString := fmt.Sprintf("%.0f / %.0f    |    %.2f%s", value, total, (value/total)*100, "%")
+	badgeString := fmt.Sprintf("%.0f / %.0f    |    %.2f%s", value, total, percentage, "%")
 
 	return badge.Render(name, badgeString, color, f)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There are cases where there have been no sig-monitoring lanes run over the 7 day period - this can break the existing percentage calculation.

Add handling for this case.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
