### PR TITLE
feat(ci-failures): add global clustering of messages

### DIFF
--- a/cmd/ci-failures/ci-failures.gomd
+++ b/cmd/ci-failures/ci-failures.gomd
@@ -26,4 +26,27 @@
 {{ template "failures" $.FailuresPerDay }}
 {{ template "failures" $.FailuresPerSIG }}
 
+## Clusters of error messages in log files
+
+<details>
+<summary>{{ len $.ClusteredSnippets }}x clusters...</summary>
+{{ range $cluster := $.ClusteredSnippets }}
+<hr/>
+
+**{{ len $cluster.Errors }}x**: <code>{{ $cluster.Representative.ErrorText }}</code> 
+<pre>{{ $cluster.Representative.Context }}</pre>
+
+[build-log]({{ $cluster.Representative.LinkToLogLine }})
+<details>
+<summary>similar...</summary>
+{{ range $snippetInCluster := $cluster.Errors }}
+<pre>{{ $snippetInCluster.Context }}</pre>
+
+[build-log]({{ $snippetInCluster.LinkToLogLine }})
+{{ end }}
+</details>
+{{ end }}
+<hr/>
+</details>
+
 Last updated: {{ $.Date }}

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -138,6 +138,7 @@ func generateMarkdown(_ *cobra.Command, _ []string) error {
 		jobBuildErrorsByJobName[jobBuildErrors.JobName] = jobBuildErrors
 	}
 
+	var allSnippets []*cifailures.BuildLogErrorSnippet
 	for _, jobBuildErrorsForJob := range jobBuildErrorsByJobName {
 
 		templateData.FailuresPerSIG.AddAll(jobBuildErrorsForJob.SIG(), jobBuildErrorsForJob)
@@ -146,8 +147,11 @@ func generateMarkdown(_ *cobra.Command, _ []string) error {
 		for _, jobBuildError := range jobBuildErrorsForJob.BuildErrors {
 			day := jobBuildError.Started.Format(time.DateOnly)
 			templateData.FailuresPerDay.AddError(day, jobBuildError)
+			allSnippets = append(allSnippets, jobBuildError.BuildLogErrorSnippets...)
 		}
 	}
+
+	templateData.ClusteredSnippets = cifailures.ClusterBuildLogErrorSnippets(allSnippets, 0.9)
 
 	file, err := os.Create("output/kubevirt/kubevirt/ci-failures/summary.md")
 	if err != nil {

--- a/cmd/ci-failures/types.go
+++ b/cmd/ci-failures/types.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 )
 
+const defaultThreshold = 0.9
+
 type ShareCategory struct {
 	CSSClassName       string
 	MinPercentageValue float64
@@ -41,7 +43,7 @@ type CategorizedFailure struct {
 	CategoryValue  string
 	Share          float64
 	JobBuildErrors []*cifailures.JobBuildError
-	Clusters       []cifailures.Cluster
+	Clusters       []cifailures.ClusteredJobBuildErrors
 	ShareCategory
 }
 
@@ -55,7 +57,7 @@ func (f *Failures) GetSortedFailures() []*CategorizedFailure {
 	var result []*CategorizedFailure
 	for categoryValue, jobBuildErrors := range f.CategorizedFailures {
 		share := float64(len(jobBuildErrors)) / float64(f.Total) * float64(100)
-		clusters := cifailures.ClusterErrors(jobBuildErrors, 0.9)
+		clusters := cifailures.ClusterErrors(jobBuildErrors, defaultThreshold)
 		categorizedFailure := &CategorizedFailure{
 			CategoryValue:  categoryValue,
 			JobBuildErrors: jobBuildErrors,
@@ -108,4 +110,5 @@ type TemplateData struct {
 	FailuresPerBranch Failures
 	FailuresPerDay    Failures
 	FailuresPerSIG    Failures
+	ClusteredSnippets []cifailures.ClusteredBuildLogErrorSnippets
 }

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -26,7 +26,7 @@ var (
 
 	// Regex to find errors in log files
 	// make: *** [Makefile:174: cluster-sync] Error 125
-	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |^make:.*Error (1[0-9]+|[2-9][0-9]*)`)
+	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |^make:.*Error (1[0-9]+|[2-9][0-9]*)|"Process did not exit before [0-9hms]+ grace period"`)
 )
 
 // ShowCIFailureJobs fetches URLs for the CI failure runs from the data of the latest run,

--- a/pkg/ci-failures/types.go
+++ b/pkg/ci-failures/types.go
@@ -5,10 +5,16 @@ import (
 	"time"
 )
 
-// Cluster holds a group of similar error messages.
-type Cluster struct {
+// ClusteredJobBuildErrors holds a group of similar job build errors.
+type ClusteredJobBuildErrors struct {
 	Representative *JobBuildError
 	Errors         []*JobBuildError
+}
+
+// ClusteredBuildLogErrorSnippets holds a group of similar error messages.
+type ClusteredBuildLogErrorSnippets struct {
+	Representative *BuildLogErrorSnippet
+	Errors         []*BuildLogErrorSnippet
 }
 
 type JobFailureData struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

At current we only cluster the last error message found per job failure.

This change adds clustering of all error messages.

<img width="1585" height="992" alt="image" src="https://github.com/user-attachments/assets/f8b4663d-fc8a-4a25-9f72-6dd4603ecf5e" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
