### PR TITLE
fix(ci-failures): avoid removing non matching expressions

### DIFF
--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/kubevirt/ci-health/pkg/prow"
+	"github.com/kubevirt/ci-health/pkg/sigretests"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	"io"
@@ -75,7 +76,7 @@ func checkJunitFuncTestXMLExists(jobURL string) (bool, error) {
 	artifactURL := strings.Replace(jobURL, "https://prow.ci.kubevirt.io//view/gs/", "https://storage.googleapis.com/", 1)
 	artifactURL = fmt.Sprintf("%s/artifacts/junit.functest.xml", artifactURL)
 
-	resp, err := http.Head(artifactURL)
+	resp, err := sigretests.HttpHeadWithRetry(artifactURL)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -231,22 +233,30 @@ func getJobsForLatestCommit(org string, repo string, prNumber string) (jobsLates
 }
 
 func HttpGetWithRetry(url string) (resp *http.Response, err error) {
-	httpRetryLog := log.WithField("url", url)
+	return DoHTTPWithRetry(url, http.Get)
+}
+
+func HttpHeadWithRetry(url string) (resp *http.Response, err error) {
+	return DoHTTPWithRetry(url, http.Head)
+}
+
+func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response, err error)) (resp *http.Response, err error) {
+	httpRetryLog := log.WithField("url", url).WithField("verb", runtime.FuncForPC(reflect.ValueOf(httpVerb).Pointer()).Name())
 	retry.Do(
 		func() error {
-			resp, err = http.Get(url)
+			resp, err = httpVerb(url)
 			switch {
 			case err != nil:
-				httpRetryLog.Debugf("failed to http get, aborting")
+				httpRetryLog.Warnf("failed with error %v, aborting", err)
 				return retry.Unrecoverable(err)
 			case resp.StatusCode == http.StatusOK:
-				httpRetryLog.Debugf("http get succeeded")
+				httpRetryLog.Debugf("succeeded")
 				return nil
 			case resp.StatusCode == http.StatusGatewayTimeout:
-				httpRetryLog.Debugf("failed to http get, will retry")
-				return fmt.Errorf("failed to http get %s (status %d): %v", url, resp.StatusCode, err)
+				httpRetryLog.Infof("failed with %d, will retry", resp.StatusCode)
+				return fmt.Errorf("failed with %d: %v", resp.StatusCode, err)
 			default:
-				httpRetryLog.Debugf("failed to http get, aborting")
+				httpRetryLog.Warnf("failed with status %d, aborting", resp.StatusCode)
 				return retry.Unrecoverable(fmt.Errorf("failed to http get %s (status %d): %v", url, resp.StatusCode, err))
 			}
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The regular expression silently filtered some urls that weren't matching (i.e. pull-kubevirt-e2e-kind-sriov) was not matching.

Since we basically don't need the sorting it's removed, now we are directly checking whether the junit is present.

Also any HEAD error was treated as a non-existing junit xml which might cover some errors - these are now returned.

Finally min and max are removed in favor of the built-ins.

/kind bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dollierp