### PR TITLE
SIG failure reports: add per-branch/job/test/date breakdowns with overall summary

### DIFF
--- a/pkg/htmlreport/main.go
+++ b/pkg/htmlreport/main.go
@@ -3,7 +3,6 @@ package htmlreport
 import (
 	_ "embed"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"html/template"
 	"io"
@@ -11,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,22 +28,60 @@ var (
 
 type HTMLReportResults struct {
 	Data struct {
-		SIGRetests struct {
-			FailedJobLeaderBoard []types.FailedJob `json:"FailedJobLeaderBoard"`
-		} `json:"SIGRetests"`
+		SIGRetests types.RunningAverageDataItem `json:"SIGRetests"`
 	} `json:"Data"`
 }
 
-type Failure struct {
-	XMLName xml.Name `xml:"failure"`
-	Message string   `xml:"message,attr"`
-	Type    string   `xml:"type,attr"`
-	Value   string   `xml:",chardata"`
+type JobWithFailures struct {
+	types.FailedJob
+	FailureRate float64
+	Total       int
+	SigFailures []SigFailure
+}
+
+type BranchStats struct {
+	Branch      string
+	Failures    int
+	Successes   int
+	Total       int
+	FailureRate float64
+	Jobs        []JobWithFailures
+}
+
+type TestFailureInstance struct {
+	JobName    string
+	FailureURL string
+	Started    time.Time
+	Error      error
+}
+
+type TestFailure struct {
+	TestName  string
+	Count     int
+	Instances []TestFailureInstance
+}
+
+type OverallStats struct {
+	TotalRuns   int
+	Failures    int
+	Successes   int
+	FailureRate float64
+}
+
+type DateFailure struct {
+	Date     string
+	Count    int
+	Failures []SigFailure
 }
 
 type ReportData struct {
-	GeneratedAt time.Time
-	Failures    []SigFailure
+	Sig          string
+	GeneratedAt  time.Time
+	Overall      OverallStats
+	BranchStats  []BranchStats
+	JobFailures  []JobWithFailures
+	TestFailures []TestFailure
+	DateFailures []DateFailure
 }
 
 type SigFailure struct {
@@ -52,6 +90,32 @@ type SigFailure struct {
 	FailureURL string
 	Started    time.Time
 	Testcase   []junit.Test
+}
+
+func getJobTargetBranch(jobName string) string {
+	parts := strings.Split(jobName, "-")
+	lastPart := parts[len(parts)-1]
+	if _, err := strconv.ParseFloat(lastPart, 32); err == nil {
+		return fmt.Sprintf("release-%s", lastPart)
+	}
+	return "main"
+}
+
+func sortBranchKeys(branches []string) {
+	sort.Slice(branches, func(i, j int) bool {
+		bi, bj := branches[i], branches[j]
+		if bi == "main" {
+			return true
+		}
+		if bj == "main" {
+			return false
+		}
+		vi := strings.TrimPrefix(bi, "release-")
+		vj := strings.TrimPrefix(bj, "release-")
+		fi, _ := strconv.ParseFloat(vi, 64)
+		fj, _ := strconv.ParseFloat(vj, 64)
+		return fi > fj
+	})
 }
 
 var jobRegexAliases = map[string]string{
@@ -174,12 +238,23 @@ func Generate(opt *types.Options) error {
 		return fmt.Errorf("invalid job regex provided: %w", err)
 	}
 
-	var sigFailures []SigFailure
-
+	// Compute per-branch stats and collect individual SIG failures grouped by branch and job
+	branchStatsMap := make(map[string]*BranchStats)
 	for _, job := range results.Data.SIGRetests.FailedJobLeaderBoard {
 		if !compiledRegex.MatchString(job.JobName) {
 			continue
 		}
+		branch := getJobTargetBranch(job.JobName)
+		bs, ok := branchStatsMap[branch]
+		if !ok {
+			bs = &BranchStats{Branch: branch}
+			branchStatsMap[branch] = bs
+		}
+		bs.Successes += job.SuccessCount
+
+		jwf := JobWithFailures{FailedJob: job}
+		jwf.FailureCount = 0
+
 		for _, failureURL := range job.FailureURLs {
 			var sigFail SigFailure
 			junitURL := constructJunitURL(failureURL)
@@ -189,7 +264,7 @@ func Generate(opt *types.Options) error {
 				continue
 			}
 			if testSuites == nil {
-				// SIG CI failure
+				// SIG CI failure - no junit results
 				continue
 			}
 			sigFail.Sig = opt.Sig
@@ -204,21 +279,144 @@ func Generate(opt *types.Options) error {
 					}
 				}
 			}
-			sigFailures = append(sigFailures, sigFail)
+			jwf.SigFailures = append(jwf.SigFailures, sigFail)
+			jwf.FailureCount++
 		}
-
+		bs.Failures += jwf.FailureCount
+		sort.Slice(jwf.SigFailures, func(i, j int) bool {
+			return jwf.SigFailures[i].Started.After(jwf.SigFailures[j].Started)
+		})
+		bs.Jobs = append(bs.Jobs, jwf)
 	}
 
-	sort.Slice(sigFailures, func(i, j int) bool {
-		return sigFailures[i].Started.After(sigFailures[j].Started)
+	var branchKeys []string
+	for k := range branchStatsMap {
+		branchKeys = append(branchKeys, k)
+	}
+	sortBranchKeys(branchKeys)
+
+	var branchStatsList []BranchStats
+	for _, k := range branchKeys {
+		bs := branchStatsMap[k]
+		bs.Total = bs.Failures + bs.Successes
+		if bs.Total > 0 {
+			bs.FailureRate = float64(bs.Failures) / float64(bs.Total) * 100
+		}
+		for i := range bs.Jobs {
+			j := &bs.Jobs[i]
+			j.Total = j.FailureCount + j.SuccessCount
+			if j.Total > 0 {
+				j.FailureRate = float64(j.FailureCount) / float64(j.Total) * 100
+			}
+		}
+		sort.Slice(bs.Jobs, func(i, j int) bool {
+			return bs.Jobs[i].FailureCount > bs.Jobs[j].FailureCount
+		})
+		branchStatsList = append(branchStatsList, *bs)
+	}
+
+	var allJobs []JobWithFailures
+	for _, bs := range branchStatsList {
+		allJobs = append(allJobs, bs.Jobs...)
+	}
+	sort.Slice(allJobs, func(i, j int) bool {
+		return allJobs[i].FailureCount > allJobs[j].FailureCount
+	})
+
+	// Aggregate test failures across all jobs and branches
+	testFailureMap := make(map[string]*TestFailure)
+	for _, jwf := range allJobs {
+		for _, sf := range jwf.SigFailures {
+			for _, tc := range sf.Testcase {
+				tf, ok := testFailureMap[tc.Name]
+				if !ok {
+					tf = &TestFailure{TestName: tc.Name}
+					testFailureMap[tc.Name] = tf
+				}
+				tf.Count++
+				tf.Instances = append(tf.Instances, TestFailureInstance{
+					JobName:    sf.JobName,
+					FailureURL: sf.FailureURL,
+					Started:    sf.Started,
+					Error:      tc.Error,
+				})
+			}
+		}
+	}
+
+	var testFailures []TestFailure
+	for _, tf := range testFailureMap {
+		testFailures = append(testFailures, *tf)
+	}
+	sort.Slice(testFailures, func(i, j int) bool {
+		return testFailures[i].Count > testFailures[j].Count
+	})
+
+	// Use the badge-level SIG retest/total stats for the overall summary
+	sigRetests := results.Data.SIGRetests
+	type sigStats struct{ retest, total float64 }
+	sigStatsMap := map[string]sigStats{
+		"compute":    {sigRetests.SIGComputeRetest, sigRetests.SIGComputeTotal},
+		"storage":    {sigRetests.SIGStorageRetest, sigRetests.SIGStorageTotal},
+		"network":    {sigRetests.SIGNetworkRetest, sigRetests.SIGNetworkTotal},
+		"operator":   {sigRetests.SIGOperatorRetest, sigRetests.SIGOperatorTotal},
+		"monitoring": {sigRetests.SIGMonitoringRetest, sigRetests.SIGMonitoringTotal},
+	}
+	ss := sigStatsMap[opt.Sig]
+	var overall OverallStats
+	overall.Failures = int(ss.retest)
+	overall.TotalRuns = int(ss.total)
+	overall.Successes = overall.TotalRuns - overall.Failures
+	if overall.TotalRuns > 0 {
+		overall.FailureRate = ss.retest / ss.total * 100
+	}
+
+	// Aggregate failures by date
+	dateFailureMap := make(map[string]*DateFailure)
+	for _, jwf := range allJobs {
+		for _, sf := range jwf.SigFailures {
+			if sf.Started.IsZero() {
+				continue
+			}
+			dateKey := sf.Started.Format("2006-01-02")
+			df, ok := dateFailureMap[dateKey]
+			if !ok {
+				df = &DateFailure{Date: dateKey}
+				dateFailureMap[dateKey] = df
+			}
+			df.Count++
+			df.Failures = append(df.Failures, sf)
+		}
+	}
+
+	var dateFailures []DateFailure
+	for _, df := range dateFailureMap {
+		sort.Slice(df.Failures, func(i, j int) bool {
+			return df.Failures[i].Started.After(df.Failures[j].Started)
+		})
+		dateFailures = append(dateFailures, *df)
+	}
+	sort.Slice(dateFailures, func(i, j int) bool {
+		return dateFailures[i].Date > dateFailures[j].Date
 	})
 
 	reportData := ReportData{
-		GeneratedAt: time.Now().UTC(),
-		Failures:    sigFailures,
+		Sig:          strings.ToUpper(opt.Sig[:1]) + opt.Sig[1:],
+		GeneratedAt:  time.Now().UTC(),
+		Overall:      overall,
+		BranchStats:  branchStatsList,
+		JobFailures:  allJobs,
+		TestFailures: testFailures,
+		DateFailures: dateFailures,
 	}
 
-	reportTemplate, err := template.New("sigFailures").Parse(sigFailureReportTemplate)
+	funcMap := template.FuncMap{
+		"buildID": func(failureURL string) string {
+			parts := strings.Split(failureURL, "/")
+			return parts[len(parts)-1]
+		},
+	}
+	reportTemplate, err := template.New("sigFailures").Funcs(funcMap).Parse(sigFailureReportTemplate)
 	if err != nil {
 		return fmt.Errorf("could not read template: %w", err)
 	}

--- a/pkg/htmlreport/sig-failure-report.gohtml
+++ b/pkg/htmlreport/sig-failure-report.gohtml
@@ -19,11 +19,44 @@
 */ -}}
 
 {{- /* sig-failure-report.gohtml */ -}}
+
+{{- define "failureCard" -}}
+                    <div class="failure-card">
+                        <a class="failure-url" href="{{ .FailureURL }}" target="_blank">{{ .FailureURL }}</a>
+                        {{- if .Testcase }}
+                        <table class="testcases">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Failure Message</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{- range .Testcase }}
+                                <tr>
+                                    <td>{{ .Name }}</td>
+                                    <td>
+                                        {{- if .Error }}
+                                            <span class="failure-message">{{ .Error }}</span>
+                                        {{- else }}
+                                            <span class="result-passed">Passed</span>
+                                        {{- end }}
+                                    </td>
+                                </tr>
+                                {{- end }}
+                            </tbody>
+                        </table>
+                        {{- else }}
+                        <p>No failed test cases found for this build.</p>
+                        {{- end }}
+                    </div>
+{{- end -}}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>SIG Failure Report</title>
+    <title>SIG {{ .Sig }} Merge Failure Report</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -37,31 +70,16 @@
             background: #fff;
             border: 1px solid #e1e4e8;
             border-radius: 8px;
-            margin-bottom: 2em;
-            padding: 1.5em 2em;
+            margin-bottom: 1em;
+            padding: 1em 1.5em;
             box-shadow: 0 2px 6px rgba(0,0,0,0.03);
-            max-width: 800px;
         }
         .failure-header {
-            margin-bottom: 1em;
-        }
-        .sig-label {
-            background: #e3fcef;
-            color: #22863a;
-            padding: 0.3em 0.7em;
-            border-radius: 16px;
-            font-weight: bold;
-            margin-right: 14px;
-            font-size: 1.1em;
-        }
-        .job-name {
-            font-size: 1.2em;
-            font-weight: bold;
-            color: #0366d6;
+            margin-bottom: 0.5em;
         }
         .failure-url {
             display: block;
-            margin-bottom: 1em;
+            margin-bottom: 0.5em;
             color: #586069;
             text-decoration: none;
             word-break: break-all;
@@ -78,7 +96,7 @@
         table.testcases {
             width: 100%;
             border-collapse: collapse;
-            margin-top: 1em;
+            margin-top: 0.5em;
         }
         table.testcases th, table.testcases td {
             border: 1px solid #e1e4e8;
@@ -101,54 +119,368 @@
             color: #d73a49;
             font-size: 0.98em;
         }
-        .test-url {
+        table.branch-summary {
+            border-collapse: collapse;
+            margin: 1.5em 0;
+            max-width: 800px;
+        }
+        table.branch-summary th, table.branch-summary td {
+            border: 1px solid #e1e4e8;
+            padding: 0.5em 1em;
+            text-align: left;
+        }
+        table.branch-summary th {
+            background: #24292e;
+            color: #fff;
+        }
+        table.branch-summary tr:nth-child(even) {
+            background: #f6f8fa;
+        }
+        .rate-high {
+            color: #d73a49;
+            font-weight: bold;
+        }
+        .rate-medium {
+            color: #e36209;
+            font-weight: bold;
+        }
+        .rate-low {
+            color: #22863a;
+            font-weight: bold;
+        }
+        details.branch-details {
+            margin: 1em 0;
+        }
+        details.branch-details > summary {
+            cursor: pointer;
+            font-size: 1.1em;
+            font-weight: bold;
+            color: #24292e;
+            padding: 0.3em 0;
+        }
+        details.job-details {
+            margin: 0.5em 0 0.5em 1em;
+        }
+        details.job-details-top {
+            margin: 0.5em 0;
+        }
+        details.job-details-top > summary {
+            cursor: pointer;
+            color: #0366d6;
+            font-size: 1em;
+            padding: 0.2em 0;
+        }
+        table.job-summary {
+            border-collapse: collapse;
+            margin: 1.5em 0;
+            max-width: 800px;
+        }
+        table.job-summary th, table.job-summary td {
+            border: 1px solid #e1e4e8;
+            padding: 0.5em 1em;
+            text-align: left;
+        }
+        table.job-summary th {
+            background: #24292e;
+            color: #fff;
+        }
+        table.job-summary tr:nth-child(even) {
+            background: #f6f8fa;
+        }
+        details.job-details > summary {
+            cursor: pointer;
+            color: #0366d6;
+            font-size: 1em;
+            padding: 0.2em 0;
+        }
+        .job-stats {
+            color: #586069;
+            font-size: 0.9em;
+        }
+        details.build-details {
+            margin: 0.5em 0 0.5em 1em;
+        }
+        details.build-details > summary {
+            cursor: pointer;
+            color: #586069;
             font-size: 0.95em;
-            color: #005cc5;
+            padding: 0.2em 0;
+        }
+        .overall-summary {
+            background: #fff;
+            border: 1px solid #e1e4e8;
+            border-radius: 8px;
+            padding: 1.5em 2em;
+            margin: 1.5em 0;
+            max-width: 800px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+        }
+        .overall-headline {
+            display: flex;
+            align-items: baseline;
+            gap: 0.6em;
+            margin-bottom: 0.5em;
+        }
+        .overall-rate {
+            font-size: 2.2em;
+            font-weight: bold;
+            line-height: 1;
+        }
+        .overall-label {
+            font-size: 1.1em;
+            color: #586069;
+        }
+        .overall-detail {
+            color: #586069;
+            font-size: 0.95em;
+            margin-top: 0.4em;
+            line-height: 1.5;
+        }
+        details.section-details {
+            margin: 1.5em 0;
+        }
+        details.section-details > summary {
+            cursor: pointer;
+            font-size: 1.3em;
+            font-weight: bold;
+            color: #24292e;
+            border-bottom: 2px solid #e1e4e8;
+            padding-bottom: 0.3em;
+            list-style: revert;
+        }
+        .toggle-controls {
+            margin: 0.5em 0;
+        }
+        .toggle-controls.top-level {
+            margin: 1em 0;
+        }
+        .toggle-btn {
+            background: #f6f8fa;
+            border: 1px solid #e1e4e8;
+            border-radius: 4px;
+            padding: 0.3em 0.8em;
+            cursor: pointer;
+            font-size: 0.85em;
+            color: #0366d6;
+            margin-right: 0.3em;
+        }
+        .toggle-btn:hover {
+            background: #e1e4e8;
         }
     </style>
+    <script>
+        function toggleAll(container, open) {
+            container.querySelectorAll('details').forEach(function(d) {
+                d.open = open;
+            });
+        }
+    </script>
 </head>
 <body>
-    <h1>SIG Failure Report</h1>
-    <p class="generated-at">Generated at {{ .GeneratedAt.Format "2006-01-02 15:04 UTC" }}</p>
-    {{- if .Failures }}
-        {{- range .Failures }}
-        <div class="failure-card">
-            <div class="failure-header">
-                <span class="sig-label">{{ .Sig }}</span>
-                <span class="job-name">{{ .JobName }}</span>
-                {{- if not .Started.IsZero }}
-                <span class="timestamp">{{ .Started.Format "2006-01-02 15:04 UTC" }}</span>
+    <h1>SIG {{ .Sig }} Merge Failure Report <span class="generated-at">— Generated at {{ .GeneratedAt.Format "2006-01-02 15:04 UTC" }}</span></h1>
+
+    {{- if .BranchStats }}
+    <div class="toggle-controls top-level">
+        <button class="toggle-btn" onclick="toggleAll(document.body, true)">Expand All</button>
+        <button class="toggle-btn" onclick="toggleAll(document.body, false)">Collapse All</button>
+    </div>
+    <div class="overall-summary">
+        <div class="overall-headline">
+            <span class="overall-rate">
+                {{- if gt .Overall.FailureRate 10.0 }}<span class="rate-high">{{ .Overall.FailureRate | printf "%.1f%%" }}</span>
+                {{- else if gt .Overall.FailureRate 5.0 }}<span class="rate-medium">{{ .Overall.FailureRate | printf "%.1f%%" }}</span>
+                {{- else }}<span class="rate-low">{{ .Overall.FailureRate | printf "%.1f%%" }}</span>
                 {{- end }}
-            </div>
-            <a class="failure-url" href="{{ .FailureURL }}" target="_blank">{{ .FailureURL }}</a>
-            {{ if .Testcase }}
-            <table class="testcases">
-                <thead>
-                    <tr>
-                        <th>Test Name</th>
-                        <th>Failure Message</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{- range .Testcase }}
-                    <tr>
-                        <td>{{ .Name }}</td>
-                        <td>
-                            {{- if .Error }}
-                                <span class="failure-message">{{ .Error }}</span>
-                            {{- else }}
-                                <span class="result-passed">Passed</span>
-                            {{- end }}
-                        </td>
-                    </tr>
-                    {{- end }}
-                </tbody>
-            </table>
-            {{ else }}
-                <p>No failed test cases found for this job.</p>
-            {{ end }}
+            </span>
+            <span class="overall-label">overall failure rate</span>
         </div>
+        <div class="overall-detail">
+            <strong>{{ .Overall.Failures }}</strong> SIG {{ .Sig }} test failures out of <strong>{{ .Overall.TotalRuns }}</strong> total job runs across all branches on merged commits over the last 7 days.
+        </div>
+    </div>
+
+    <details class="section-details">
+        <summary>Failure Rate by Branch</summary>
+        <div class="toggle-controls">
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), true)">Expand All</button>
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), false)">Collapse All</button>
+        </div>
+        <table class="branch-summary">
+            <thead>
+                <tr>
+                    <th>Branch</th>
+                    <th>Failures</th>
+                    <th>Successes</th>
+                    <th>Total</th>
+                    <th>Failure Rate</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range .BranchStats }}
+                <tr>
+                    <td><strong>{{ .Branch }}</strong></td>
+                    <td>{{ .Failures }}</td>
+                    <td>{{ .Successes }}</td>
+                    <td>{{ .Total }}</td>
+                    <td>
+                        {{- if gt .FailureRate 10.0 }}<span class="rate-high">{{ .FailureRate | printf "%.1f%%" }}</span>
+                        {{- else if gt .FailureRate 5.0 }}<span class="rate-medium">{{ .FailureRate | printf "%.1f%%" }}</span>
+                        {{- else }}<span class="rate-low">{{ .FailureRate | printf "%.1f%%" }}</span>
+                        {{- end }}
+                    </td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+
+        {{- range .BranchStats }}
+        <details class="branch-details">
+            <summary>{{ .Branch }} ({{ .Failures }} failures across {{ len .Jobs }} jobs)</summary>
+            {{- range .Jobs }}
+            <details class="job-details">
+                <summary>{{ .JobName }} <span class="job-stats">— {{ .FailureCount }}F / {{ .SuccessCount }}S ({{ .FailureRate | printf "%.1f%%" }})</span></summary>
+                {{- range .SigFailures }}
+                <details class="build-details">
+                    <summary>{{ buildID .FailureURL }}{{- if not .Started.IsZero }} — {{ .Started.Format "2006-01-02 15:04 UTC" }}{{ end }}</summary>
+                    {{- template "failureCard" . }}
+                </details>
+                {{- end }}
+            </details>
+            {{- end }}
+        </details>
         {{- end }}
+    </details>
+
+    {{- if .JobFailures }}
+    <details class="section-details">
+        <summary>Failure Rate by Job</summary>
+        <div class="toggle-controls">
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), true)">Expand All</button>
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), false)">Collapse All</button>
+        </div>
+        <table class="job-summary">
+            <thead>
+                <tr>
+                    <th>Job</th>
+                    <th>Failures</th>
+                    <th>Successes</th>
+                    <th>Total</th>
+                    <th>Failure Rate</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range .JobFailures }}
+                <tr>
+                    <td>{{ .JobName }}</td>
+                    <td>{{ .FailureCount }}</td>
+                    <td>{{ .SuccessCount }}</td>
+                    <td>{{ .Total }}</td>
+                    <td>
+                        {{- if gt .FailureRate 10.0 }}<span class="rate-high">{{ .FailureRate | printf "%.1f%%" }}</span>
+                        {{- else if gt .FailureRate 5.0 }}<span class="rate-medium">{{ .FailureRate | printf "%.1f%%" }}</span>
+                        {{- else }}<span class="rate-low">{{ .FailureRate | printf "%.1f%%" }}</span>
+                        {{- end }}
+                    </td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+
+        {{- range .JobFailures }}
+        <details class="job-details-top">
+            <summary>{{ .JobName }} <span class="job-stats">— {{ .FailureCount }}F / {{ .SuccessCount }}S ({{ .FailureRate | printf "%.1f%%" }})</span></summary>
+            {{- range .SigFailures }}
+            <details class="build-details">
+                <summary>{{ buildID .FailureURL }}{{- if not .Started.IsZero }} — {{ .Started.Format "2006-01-02 15:04 UTC" }}{{ end }}</summary>
+                {{- template "failureCard" . }}
+            </details>
+            {{- end }}
+        </details>
+        {{- end }}
+    </details>
+    {{- end }}
+
+    {{- if .TestFailures }}
+    <details class="section-details">
+        <summary>Failure Rate by Test</summary>
+        <div class="toggle-controls">
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), true)">Expand All</button>
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), false)">Collapse All</button>
+        </div>
+        <table class="job-summary">
+            <thead>
+                <tr>
+                    <th>Test Name</th>
+                    <th>Failure Count</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range .TestFailures }}
+                <tr>
+                    <td>{{ .TestName }}</td>
+                    <td>{{ .Count }}</td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+
+        {{- range .TestFailures }}
+        <details class="job-details-top">
+            <summary>{{ .TestName }} <span class="job-stats">— {{ .Count }} failure{{ if ne .Count 1 }}s{{ end }}</span></summary>
+            {{- range .Instances }}
+            <details class="build-details">
+                <summary>{{ .JobName }} / {{ buildID .FailureURL }}{{- if not .Started.IsZero }} — {{ .Started.Format "2006-01-02 15:04 UTC" }}{{ end }}</summary>
+                <div class="failure-card">
+                    <a class="failure-url" href="{{ .FailureURL }}" target="_blank">{{ .FailureURL }}</a>
+                    {{- if .Error }}
+                    <p><span class="failure-message">{{ .Error }}</span></p>
+                    {{- end }}
+                </div>
+            </details>
+            {{- end }}
+        </details>
+        {{- end }}
+    </details>
+    {{- end }}
+
+    {{- if .DateFailures }}
+    <details class="section-details">
+        <summary>Failure Rate by Date</summary>
+        <div class="toggle-controls">
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), true)">Expand All</button>
+            <button class="toggle-btn" onclick="toggleAll(this.closest('details'), false)">Collapse All</button>
+        </div>
+        <table class="job-summary">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Failures</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range .DateFailures }}
+                <tr>
+                    <td>{{ .Date }}</td>
+                    <td>{{ .Count }}</td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+
+        {{- range .DateFailures }}
+        <details class="job-details-top">
+            <summary>{{ .Date }} <span class="job-stats">— {{ .Count }} failure{{ if ne .Count 1 }}s{{ end }}</span></summary>
+            {{- range .Failures }}
+            <details class="build-details">
+                <summary>{{ .JobName }} / {{ buildID .FailureURL }}{{- if not .Started.IsZero }} — {{ .Started.Format "15:04 UTC" }}{{ end }}</summary>
+                {{- template "failureCard" . }}
+            </details>
+            {{- end }}
+        </details>
+        {{- end }}
+    </details>
+    {{- end }}
+
     {{- else }}
         <p>No SIG failures to display.</p>
     {{- end }}


### PR DESCRIPTION
## Summary

Restructures the SIG failure report as the **SIG Merge Failure Report** with:

- **Overall summary** at the top matching the badge stats (failures / total runs | failure rate)
- **Failure Rate by Branch** — collapsible section with summary table and nested per-job/build details
- **Failure Rate by Job** — collapsible section with summary table and nested per-build details
- **Failure Rate by Test** — collapsible section listing tests that have failed at least once, with per-instance details
- **Failure Rate by Date** — collapsible section showing failures grouped by day
- **Expand/Collapse All** controls at the top level and within each section
- Color-coded failure rates: green <=5%, yellow <=10%, red >10%

## Preview

### Collapsed view
<img width="1200" height="500" alt="sig-compute-collapsed" src="https://github.com/lyarwood/ci-health/releases/download/untagged-2f7c807e350dbbc4632a/sig-compute-collapsed-cropped.png" />

### Expanded view
<img width="1200" height="3000" alt="sig-compute-expanded" src="https://github.com/lyarwood/ci-health/releases/download/untagged-2f7c807e350dbbc4632a/sig-compute-expanded-cropped.png" />