### PR TITLE
feat: add Claude skills, AGENTS.md, and remove stale Bazel triggers

### DIFF
--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: analyze-build
+description: >
+    Analyze the root cause inside a failed prowjob.
+    Use when user mentions to analyze a prowjob failure or adds a prowjob url
+allowed-tools: [Read, Write, Bash(go run:*)]
+---
+
+## Overview
+
+This skill helps the user to find the root cause and mitigations for failing prowjobs.
+
+## Analysis data generation
+
+As a base for analyzing the failure, the go tool `cmd/ci-failures` from this project is to be used.
+
+Example how to generate the data file for a specific prowjob, given is the url to the prowjob build:
+
+```bash
+$ go run ./cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
+{"level":"info","msg":"wrote analysis to output/tmp/pull-kubevirt-e2e-k8s-1.34-windows2016.yaml","time":"2026-03-30T13:37:48+02:00"}
+```
+
+Note: the output shows the path to the generated file containing the base data for the analysis. 
+
+## Analysis
+
+The output is to be looked at and the reason and possible mitigations are to be deduced from this.

--- a/.claude/skills/analyze-ci-failures/SKILL.md
+++ b/.claude/skills/analyze-ci-failures/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: analyze-ci-failures
+description: >
+    Analyze root causes for all the recent ci-failures.
+    Use when user mentions to analyze recent ci failures
+allowed-tools: [Read, Write, Glob, Grep, Bash(go run:*), Bash(stat:*), Bash(ls:*), Bash(git fetch:*), Bash(git diff:*)]
+---
+
+## Overview
+
+This skill helps the user to find the root cause and mitigations for all ci failures aka failing prowjobs that have not reached the testing stage.
+
+## Analysis data generation
+
+As a base for analyzing the failure, the go tool `cmd/ci-failures` from this project is to be used. As a base for the data the file
+`output/kubevirt/kubevirt/results.json` is used.
+
+Example how to generate the data files for the prowjobs failing ci:
+
+```bash
+$ go run ./cmd/ci-failures generate yaml
+```
+
+This produces:
+- `output/tmp/errors-{sig}/*.yaml` — per-job error extractions with snippets, line links, and context
+- `output/tmp/build-logs/{buildID}.yaml` — full cached build logs with prow URL, GCS URL, timestamps, and complete log content
+
+### Stale data
+Before you proceed, 
+1) check whether there's updates on `output/kubevirt/kubevirt/results.json` available on the main branch - in that case first update the current branch with latest changes by rebasing on main.
+2) compare `output/tmp` file time stamps with `output/kubevirt/kubevirt/results.json` - if the files in `output/tmp` are older than the latter, they are stale and need to get deleted.
+
+To compare timestamps, use `ls -lt` to list both files together — the newer file appears first:
+```bash
+$ ls -lt output/kubevirt/kubevirt/results.json output/tmp/errors-*/*.yaml
+```
+If `results.json` appears above (newer than) the error YAML files, the generated data is stale.
+
+To delete stale data, remove the entire `output/tmp` directory:
+```bash
+$ rm -rf output/tmp/*
+```
+
+## Data Available in the YAML Files
+
+### Error YAML files (`output/tmp/errors-{sig}/*.yaml`)
+
+Each file contains structured data — most metadata can be read directly without parsing URLs:
+
+- **SIG**: encoded in the parent directory name (e.g., `errors-sig-compute/`, `errors-sig-network/`, `errors-sig-storage/`, `errors-sig-monitoring/`, `errors-sig-performance/`)
+- **Job name** (`job_name` field): the Prow job name, e.g., `pull-kubevirt-e2e-k8s-1.35-sig-network`
+- **Branch**: deducible from `job_name` — if it ends with a version suffix like `-1.6`, it targets `release-1.6`; no suffix means `main`
+- **Kubernetes version**: deducible from `job_name` — the `k8s-X.Y` or `kind-X.Y` segment gives the K8s version (e.g., `1.35`)
+- **PR number**: deducible from `job_url` — the segment after `pull/kubevirt_kubevirt/` (e.g., `17129`)
+- **Build errors** (`build_errors` list), each containing:
+    - `job_url`: direct link to the Prow job UI
+    - `build_id`: the Prow build number (also usable to find the full build log)
+    - `started` / `finished`: timestamps
+    - `build_log_error_snippets`: list of extracted error matches, each with:
+        - `error_text`: the matched error line
+        - `context`: surrounding lines (typically 3 before and after) — this is the primary source for root cause analysis
+        - `link_to_log_line`: direct link to the error line in Prow UI
+        - `start_line`, `error_line`, `end_line`: line numbers in the build log
+
+### Full build log files (`output/tmp/build-logs/{buildID}.yaml`)
+
+Only needed when error snippets are insufficient for root cause analysis. Structure:
+- `prow_job_url`: link to the Prow job
+- `build_log_url`: GCS URL for the raw build log
+- `log_content`: the complete build log text
+- `started` / `finished`: timestamps
+
+These files can be very large. When reading them, start searching from the end since failures appear at the bottom.
+
+## Procedure
+
+1. **Discover error files**: Use Glob to find all `output/tmp/errors-*/*.yaml` files
+2. **Read each error YAML file**: Extract the job name, SIG (from directory), and all build errors with their snippets
+3. **Analyze error snippets**: For each build error, examine `error_text` and `context` fields to determine root cause. In most cases the snippets contain enough information
+4. **Deep-dive when needed**: If snippets are ambiguous, read the full build log from `output/tmp/build-logs/{build_id}.yaml`
+5. **Classify** each failure as fixable or non-fixable
+6. **Group similar failures** across jobs — errors with the same root cause should be combined into a single group even if they appear in different SIGs or branches
+
+## Goal for analysis
+
+The output is to be looked at as described above, then reasons and possible mitigations are to be deduced.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,10 +6,6 @@ on:
     - 'e2e/**'
     - 'pkg/**'
     - 'go.*'
-    - 'deps.bzl'
-    - 'BUILD.bazel'
-    - 'WORKSPACE'
-    - '.bazel*'
     - '.github/**'
 jobs:
   test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## Project Purpose
+
+The `ci-health` project is a Go-based tool designed to analyze and report on the performance of the KubeVirt organization's CI/CD system, which is built on Prow. It calculates key metrics to provide insights into the health and efficiency of the development and testing pipeline.
+
+The primary metrics tracked are:
+- **Merge Queue Length**: The number of pull requests ready to be merged at any given time.
+- **Time to Merge**: The duration it takes for a PR to be merged after it enters the merge queue.
+- **Retests to Merge**: The number of `/test` or `/retest` commands issued on a PR before it merges.
+- **Failures per SIG**: Tracks test failures attributed to different Special Interest Groups (SIGs).
+- **Quarantined Tests**: Monitors the number of tests that are temporarily disabled due to flakiness.
+
+The output of this tool is a set of SVG badges and PNG plots that are embedded in the `README.md` to provide a real-time dashboard of CI health.
+
+## Project Structure
+
+The project is organized into two main directories: `cmd` and `pkg`.
+
+### `cmd/` - Command-Line Applications
+
+This directory contains the entry points for the executable tools:
+
+- **`stats/`**: A tool that gathers data from the most recent period (e.g., the last 7 days), calculates metrics, and generates SVG badges. This is used for the near real-time status in the README.
+- **`batch/`**: A tool for processing historical data. It can fetch data for a specified date range and then generate plots (PNG images) to visualize trends over time.
+- **`html-report/`**: A tool to generate detailed HTML reports of test failures, categorized by SIG.
+- **`ci-failures/`**: A tool that extracts information about jobs that have failed before the test phase for a lane has started. It downloads build logs, extracts error snippets, and generates markdown reports to drill down on these failures.
+
+### `pkg/` - Core Libraries
+
+This directory contains the packages that implement the core logic of the `ci-health` tool:
+
+- **`chatops/`**: Provides primitives for querying data about actions triggered by comments in GitHub repos managed by Prow, such as analyzing `/retest` and `/test` comments for merge time and retry count calculations.
+- **`ci-failures/`**: Provides the core logic for fetching, downloading, and processing CI failures, including clustering similar errors.
+- **`constants/`**: Defines application-wide constants including date formats, metric names, badge file names, label patterns, and default configuration values.
+- **`gh/`**: Handles interactions with the GitHub API to fetch data about pull requests, labels, and comments.
+- **`htmlreport/`**: Generates HTML reports of CI failures and test metrics using embedded Go templates, including parsing JUnit XML test reports for SIG-specific failure analysis.
+- **`mergequeue/`**, **`metrics/`**, **`stats/`**: Contain the logic for calculating the defined CI metrics.
+- **`output/`**: Manages the writing of results, such as JSON data, SVG badges, and plots, to the filesystem.
+- **`plot/`**: Implements the functionality to generate PNG plots from historical data.
+- **`prow/`**: Contains data type definitions for Prow job metadata including started/finished job events with timestamps, pull request information, and test results.
+- **`quarantine/`**: Logic specific to tracking and reporting on quarantined tests.
+- **`runner/`**: Orchestrates the execution of batch and stats operations by coordinating between GitHub client, merge queue handler, and chatops handler.
+- **`sigretests/`**: Logic for attributing retests and failures to the responsible SIGs.
+- **`timeutils/`**: Provides utility functions for date/time manipulation, such as finding the closest Monday date.
+- **`types/`**: Defines core application types such as Metric enum, Actions, Options, Results, and PR structures used throughout the codebase.
+
+## Development Workflow
+
+### Draft Pull Requests
+
+**IMPORTANT**: When creating pull requests, ALWAYS create them as drafts using `gh pr create --draft`.
+
+This applies to all PRs regardless of size or scope. The author will mark them as ready for review when appropriate.
+
+## GitHub Actions Workflows
+
+The repository uses GitHub Actions to automate the process of data collection, report generation, and testing.
+
+### `test.yaml`
+
+- **Trigger**: Runs on pull requests that modify Go source files (`cmd/`, `pkg/`, `e2e/`), Go module files (`go.*`), or the workflows themselves (`.github/`).
+- **Purpose**: To ensure the integrity of the codebase.
+- **Action**: It executes `go test ./...` to run all the unit tests in the project. This prevents regressions and ensures that new code is tested.
+
+### `badges-update.yaml`
+
+- **Trigger**: Runs on a schedule (every 3 hours) and can also be dispatched manually.
+- **Purpose**: To keep the CI health status badges in the `README.md` up-to-date with the latest data.
+- **Action**:
+    1. Checks out the repository.
+    2. Runs the `stats` command to fetch data for the last 7 days for the `kubevirt/kubevirt` repository.
+    3. The command overwrites the SVG badges and JSON results in the `output/` directory.
+    4. A subsequent step commits the updated files back to the repository.
+
+### `ci-failures.yml`
+
+- **Trigger**: Runs on pushes to `main` that modify `output/kubevirt/kubevirt/results.json`.
+- **Purpose**: To automatically regenerate the CI failures summary report whenever new results data is committed.
+- **Action**:
+    1. Checks out the repository.
+    2. Runs `go run ./cmd/ci-failures generate report` to produce an updated markdown summary of CI failures.
+    3. Commits the updated output files back to the repository.
+
+### `historical-update.yaml`
+
+- **Trigger**: Runs on a schedule (weekly, every Monday at 00:10 UTC).
+- **Purpose**: To track and visualize long-term CI health trends.
+- **Action**:
+    1. Checks out the repository.
+    2. Runs the `batch` command in `fetch` and then `plot` mode for several key metrics: `retests-to-merge`, `time-to-merge`, `merge-queue-length`, `merged-prs`, and `quarantined-tests`.
+    3. This process updates the historical data files and regenerates the trend plots (PNG images).
+    4. A final step commits the updated data and plots back to the repository.


### PR DESCRIPTION
## Summary

- **Add AGENTS.md**: Comprehensive project documentation for AI agents covering project purpose, structure, development workflow, and GitHub Actions workflows
- **Add Claude skills**: Two new skills for CI failure analysis:
  - `analyze-build` — analyzes root cause of a single failing Prow job given its URL
  - `analyze-ci-failures` — analyzes all recent CI failures, grouping similar errors across SIGs and branches
- **Remove stale Bazel triggers** from `.github/workflows/test.yaml`: the project no longer uses Bazel, so the workflow trigger paths for `deps.bzl`, `BUILD.bazel`, `WORKSPACE`, and `.bazel*` are removed

## Details

### AGENTS.md

Provides structured context so AI agents can effectively work with the codebase. Documents:
- Project purpose and the key CI health metrics tracked (merge queue length, time to merge, retests to merge, failures per SIG, quarantined tests)
- Directory structure for `cmd/` (stats, batch, html-report, ci-failures) and `pkg/` (chatops, ci-failures, constants, gh, htmlreport, mergequeue, metrics, output, plot, prow, quarantine, runner, sigretests, stats, timeutils, types)
- Development workflow conventions (draft PRs)
- GitHub Actions workflow descriptions (test, badges-update, ci-failures, historical-update)

### Claude Skills

**`analyze-build`**: Given a Prow job URL, runs `go run ./cmd/ci-failures analyze-build <url>` to generate a YAML analysis file, then inspects it to deduce root cause and possible mitigations.

**`analyze-ci-failures`**: Discovers all generated error YAML files under `output/tmp/errors-{sig}/`, reads error snippets and context, classifies failures as fixable or non-fixable, and groups similar failures across jobs. Includes stale data detection logic to ensure analysis is based on current results.

### Workflow Cleanup

Removes four Bazel-related path triggers (`deps.bzl`, `BUILD.bazel`, `WORKSPACE`, `.bazel*`) from the test workflow since the project migrated away from Bazel.

## Test plan

- [ ] Verify `go test ./...` passes (no code changes, only config/docs)
- [ ] Confirm the test workflow still triggers correctly on Go source and workflow file changes
- [ ] Validate the two Claude skills work by running `analyze-build` with a sample Prow URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)