### PR TITLE
Add analyze-pr command for PR build failure analysis

### DIFF
--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: analyze-pr-builds
+description: >
+    Analyze all failed builds for a GitHub pull request.
+    Use when user provides a GitHub PR URL and wants to understand why builds are failing.
+allowed-tools: [Read, Glob, Bash(go run:*)]
+---
+
+## Overview
+
+This skill analyzes all currently-failing builds for a GitHub pull request, identifies root causes, and presents a concise summary.
+
+It works for any repo served by prow.ci.kubevirt.io (currently the `kubevirt` GitHub org).
+
+## Data Generation
+
+Run the `analyze-pr` command with the GitHub PR URL to fetch and analyze all failed builds:
+
+```bash
+$ go run ./cmd/ci-failures analyze-pr https://github.com/kubevirt/kubevirt/pull/17287
+```
+
+This command:
+1. Fetches the PR history from prow
+2. Finds all jobs for the latest commit
+3. Keeps only the latest run per job (jobs that eventually passed are excluded)
+4. Downloads build logs and extracts error snippets for each failure
+5. Writes one YAML file per failed job to `output/tmp/{job-name}.yaml`
+
+## Analysis
+
+After data generation:
+
+1. Use Glob to find all `output/tmp/*.yaml` files produced by the command
+2. Read each YAML file. The structure is:
+   - `job_name`: the Prow job name
+   - `build_errors`: list of build errors, each containing:
+     - `job_url`: link to the Prow job UI
+     - `build_id`: the build number
+     - `started` / `finished`: timestamps
+     - `category`: error category (external, internal, pr-build, needs-investigation)
+     - `category_reason`: explanation of the categorization
+     - `build_log_error_snippets`: list of error matches with `error_text`, `context`, and `link_to_log_line`
+3. For each failure, examine the `error_text` and `context` fields to determine the root cause
+4. Group failures with the same root cause together
+
+## Output
+
+Present a concise summary to the user:
+- Group failures by root cause
+- For each group: state the root cause, list affected jobs, and include one representative error snippet
+- Classify each as **fixable** (CI config or code issue) or **non-fixable** (external/infra)
+- Include the `link_to_log_line` for the most relevant error in each group

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 
 	cifailures "github.com/kubevirt/ci-health/pkg/ci-failures"
+	"github.com/kubevirt/ci-health/pkg/sigretests"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -61,6 +63,19 @@ var (
 		Short: "Analyze a single build failure given a Prow job URL and output YAML.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  analyzeBuild,
+	}
+
+	analyzePRCmd = &cobra.Command{
+		Use:   "analyze-pr [github-pr-url]",
+		Short: "Analyze all failed builds for a GitHub PR.",
+		Long: `Analyze all failed builds for a GitHub PR.
+
+Accepts a GitHub pull request URL, e.g.:
+  https://github.com/kubevirt/kubevirt/pull/17287
+
+Only repos served by prow.ci.kubevirt.io are supported.`,
+		Args: cobra.ExactArgs(1),
+		RunE: analyzePR,
 	}
 )
 
@@ -192,12 +207,79 @@ func analyzeBuild(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+var allowedOrgs = map[string]bool{
+	"kubevirt": true,
+}
+
+func parsePRURL(prURL string) (org, repo, prNumber string, err error) {
+	const prefix = "https://github.com/"
+	if !strings.HasPrefix(prURL, prefix) {
+		return "", "", "", fmt.Errorf("expected a GitHub PR URL (https://github.com/org/repo/pull/N), got: %s", prURL)
+	}
+	parts := strings.Split(strings.TrimPrefix(prURL, prefix), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return "", "", "", fmt.Errorf("invalid GitHub PR URL format: %s", prURL)
+	}
+	org = parts[0]
+	repo = parts[1]
+	prNumber = parts[3]
+	if _, parseErr := strconv.Atoi(prNumber); parseErr != nil {
+		return "", "", "", fmt.Errorf("invalid PR number in URL: %s", prNumber)
+	}
+	if !allowedOrgs[org] {
+		return "", "", "", fmt.Errorf("org %q is not served by prow.ci.kubevirt.io (allowed: %v)", org, allowedOrgs)
+	}
+	return org, repo, prNumber, nil
+}
+
+func analyzePR(_ *cobra.Command, args []string) error {
+	prOrg, prRepo, prNumber, err := parsePRURL(args[0])
+	if err != nil {
+		return err
+	}
+
+	failedURLs, err := sigretests.ListPRFailures(prNumber, prOrg, prRepo)
+	if err != nil {
+		return fmt.Errorf("failed to list PR failures: %v", err)
+	}
+
+	if len(failedURLs) == 0 {
+		log.Info("no failed builds found for this PR")
+		return nil
+	}
+
+	log.Infof("found %d failed build(s)", len(failedURLs))
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	for _, url := range failedURLs {
+		jobBuildErrors, err := cifailures.AnalyzeBuild(url)
+		if err != nil {
+			log.WithError(err).Warnf("failed to analyze build %s, skipping", url)
+			continue
+		}
+
+		outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("%s.yaml", jobBuildErrors.JobName))
+		if err = cifailures.WriteJobBuildErrorsYAML(outputPath, jobBuildErrors); err != nil {
+			log.WithError(err).Warnf("failed to write YAML for %s", jobBuildErrors.JobName)
+			continue
+		}
+
+		log.Infof("wrote analysis to %s", outputPath)
+	}
+
+	return nil
+}
+
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
 
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(analyzeBuildCmd)
+	rootCmd.AddCommand(analyzePRCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -309,6 +309,99 @@ func getJobTargetBranch(jobName string) string {
 	return "main"
 }
 
+func parseAllJobs(node *html.Node, prOrg, prRepo string) []job {
+	var jobs []job
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "td" {
+			var isFailure, isSuccess bool
+			for _, attr := range n.Attr {
+				if strings.Contains(attr.Val, "run-failure") {
+					isFailure = true
+				}
+				if strings.Contains(attr.Val, "run-success") {
+					isSuccess = true
+				}
+			}
+			if (isFailure || isSuccess) && n.FirstChild != nil {
+				for _, attr := range n.FirstChild.Attr {
+					if attr.Key == "href" {
+						parts := strings.Split(attr.Val, "/")
+						if len(parts) >= 2 {
+							j := job{
+								failure:     isFailure,
+								buildURL:    fmt.Sprintf("https://prow.ci.kubevirt.io%s", attr.Val),
+								jobName:     parts[len(parts)-2],
+								buildNumber: parts[len(parts)-1],
+							}
+							if isFailure && len(parts) >= 3 {
+								prNumber := parts[len(parts)-3]
+								j.artifactsURL = fmt.Sprintf("%s/pr-logs/pull/%s_%s/%s/%s/%s/artifacts",
+									defaultStorageBaseURL, prOrg, prRepo, prNumber, j.jobName, j.buildNumber)
+							}
+							jobs = append(jobs, j)
+						}
+					}
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return jobs
+}
+
+// ListPRFailures returns the Prow build URLs of the latest failed run per job
+// for the most recent commit on the given PR. Jobs whose latest run succeeded
+// are excluded, so only currently-failing jobs are returned.
+func ListPRFailures(prNumber, prOrg, prRepo string) ([]string, error) {
+	prHistory := prHistoryURL(prOrg, prRepo, prNumber)
+	resp, err := HttpGetWithRetry(prHistory)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	prHistoryPage, err := html.Parse(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing history page: %s", err)
+	}
+	latestCommit := getLatestCommit(prHistoryPage)
+	if latestCommit == "" {
+		return nil, fmt.Errorf("failed to get latest commit from %s", prHistory)
+	}
+
+	allJobs := parseAllJobs(prHistoryPage, prOrg, prRepo)
+
+	latestCommitJobs, err := filterForLastCommit(defaultStorageBaseURL, prOrg, prRepo, prNumber, latestCommit, allJobs, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+
+	latestByJob := map[string]job{}
+	for _, j := range latestCommitJobs {
+		if existing, ok := latestByJob[j.jobName]; ok {
+			existingNum, _ := strconv.Atoi(existing.buildNumber)
+			currentNum, _ := strconv.Atoi(j.buildNumber)
+			if currentNum > existingNum {
+				latestByJob[j.jobName] = j
+			}
+		} else {
+			latestByJob[j.jobName] = j
+		}
+	}
+
+	var failedURLs []string
+	for _, j := range latestByJob {
+		if j.failure {
+			failedURLs = append(failedURLs, j.buildURL)
+		}
+	}
+	return failedURLs, nil
+}
+
 func FilterJobsPerSigs(jobs []job, supportedBranches []string) (prSigRetests SigRetests) {
 	prSigRetests = SigRetests{}
 	for _, job := range jobs {


### PR DESCRIPTION
## Summary

- Adds `analyze-pr` CLI command that accepts a GitHub PR URL, discovers all failed builds for the latest commit, and runs error extraction on each
- Adds `ListPRFailures` function with a new `parseAllJobs` HTML parser that collects **all** job types (not just e2e), skips optional-job and branch filters, and deduplicates to the latest run per job
- Adds `analyze-pr-builds` Claude skill that orchestrates the command and summarizes root causes

## Test plan

- [ ] Run `go build ./cmd/ci-failures/` — compiles cleanly
- [ ] Run `go run ./cmd/ci-failures analyze-pr https://github.com/kubevirt/kubevirt/pull/17287` against a real PR
- [ ] Verify YAML files are written to `output/tmp/` for each failed job
- [ ] Verify that jobs which passed on the latest retest are excluded
- [ ] Verify that non-e2e jobs (unit tests, builds, checks) are included when they fail
- [ ] Verify that a non-kubevirt org URL is rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)