### PR TITLE
feat: add analyze-k8s subcommand for k8s-reporter artifact analysis

### DIFF
--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -10,9 +10,10 @@ allowed-tools: [Read, Glob, Bash(go run:*)]
 
 This skill helps the user to find the root cause and mitigations for failing prowjobs.
 
-It combines two analyses:
+It combines three analyses:
 1. **Build log analysis** — extracts error snippets from the build log and categorizes them
 2. **Kubernetes cluster state analysis** — downloads k8s-reporter artifacts (pods, nodes, events, VMIs) and detects infrastructure-level failures like CrashLoopBackOff, OOMKilled, NotReady nodes, failed migrations, and warning events
+3. **Etcd storage profiling** — if the job was run with `KUBEVIRT_PROFILE_ETCD=true`, downloads `etcd-storage-profile.json` from `artifacts/etcd-profiler/` and detects tmpfs exhaustion, tmpfs pressure, large WAL files, and DB growth trends
 
 ## Analysis data generation
 
@@ -24,9 +25,9 @@ Example how to generate the data files for a specific prowjob, given is the url 
 $ go run ./cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
 ```
 
-This produces two output files:
+This produces up to three output files:
 - `output/tmp/{job-name}.yaml` — build log error analysis
-- `output/tmp/k8s-analysis-{build-id}.yaml` — kubernetes cluster state analysis (if k8s-reporter artifacts exist)
+- `output/tmp/k8s-analysis-{build-id}.yaml` — kubernetes cluster state analysis (if k8s-reporter artifacts exist), includes etcd profiler findings and full etcd profile data when available
 
 ## Analysis
 
@@ -40,5 +41,6 @@ After data generation:
    - `snapshots`: list of cluster state capture points (process + failure count)
    - `findings`: list of detected issues, each with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
    - `summary`: aggregate counts by kind, severity, and detector
-4. Correlate both analyses: k8s findings (e.g. CrashLoopBackOff on a component pod) often explain build log errors (e.g. test timeouts)
+   - `etcd_profile` (optional): full etcd storage profile with `peak_tmpfs_used_bytes`, `final_tmpfs_total_bytes`, `final_wal_size_bytes`, and per-spec `records` showing DB size deltas and tmpfs usage. Etcd-related findings use kind `EtcdProfile` and detectors `etcd-tmpfs-exhaustion`, `etcd-tmpfs-pressure`, `etcd-large-wal`, `etcd-db-growth`
+4. Correlate all analyses: k8s findings (e.g. CrashLoopBackOff on a component pod) often explain build log errors (e.g. test timeouts); etcd findings (e.g. tmpfs exhaustion) can explain node-level or apiserver issues
 5. Deduce the root cause and possible mitigations from the combined data

--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -3,26 +3,42 @@ name: analyze-build
 description: >
     Analyze the root cause inside a failed prowjob.
     Use when user mentions to analyze a prowjob failure or adds a prowjob url
-allowed-tools: [Read, Write, Bash(go run:*)]
+allowed-tools: [Read, Glob, Bash(go run:*)]
 ---
 
 ## Overview
 
 This skill helps the user to find the root cause and mitigations for failing prowjobs.
 
+It combines two analyses:
+1. **Build log analysis** — extracts error snippets from the build log and categorizes them
+2. **Kubernetes cluster state analysis** — downloads k8s-reporter artifacts (pods, nodes, events, VMIs) and detects infrastructure-level failures like CrashLoopBackOff, OOMKilled, NotReady nodes, failed migrations, and warning events
+
 ## Analysis data generation
 
 As a base for analyzing the failure, the go tool `cmd/ci-failures` from this project is to be used.
 
-Example how to generate the data file for a specific prowjob, given is the url to the prowjob build:
+Example how to generate the data files for a specific prowjob, given is the url to the prowjob build:
 
 ```bash
 $ go run ./cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
-{"level":"info","msg":"wrote analysis to output/tmp/pull-kubevirt-e2e-k8s-1.34-windows2016.yaml","time":"2026-03-30T13:37:48+02:00"}
 ```
 
-Note: the output shows the path to the generated file containing the base data for the analysis. 
+This produces two output files:
+- `output/tmp/{job-name}.yaml` — build log error analysis
+- `output/tmp/k8s-analysis-{build-id}.yaml` — kubernetes cluster state analysis (if k8s-reporter artifacts exist)
 
 ## Analysis
 
-The output is to be looked at and the reason and possible mitigations are to be deduced from this.
+After data generation:
+
+1. Use Glob to find all `output/tmp/*.yaml` files produced by the command
+2. Read the build log analysis YAML (`{job-name}.yaml`). The structure is:
+   - `job_name`: the Prow job name
+   - `build_errors`: list of build errors with `category`, `category_reason`, and `build_log_error_snippets`
+3. Read the k8s analysis YAML (`k8s-analysis-*.yaml`) if present. The structure is:
+   - `snapshots`: list of cluster state capture points (process + failure count)
+   - `findings`: list of detected issues, each with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
+   - `summary`: aggregate counts by kind, severity, and detector
+4. Correlate both analyses: k8s findings (e.g. CrashLoopBackOff on a component pod) often explain build log errors (e.g. test timeouts)
+5. Deduce the root cause and possible mitigations from the combined data

--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -26,13 +26,14 @@ This command:
 3. Keeps only the latest run per job (jobs that eventually passed are excluded)
 4. Downloads build logs and extracts error snippets for each failure
 5. Writes one YAML file per failed job to `output/tmp/{job-name}.yaml`
+6. For each failed job, also downloads k8s-reporter artifacts and writes `output/tmp/k8s-analysis-{build-id}.yaml`
 
 ## Analysis
 
 After data generation:
 
 1. Use Glob to find all `output/tmp/*.yaml` files produced by the command
-2. Read each YAML file. The structure is:
+2. Read each build log YAML (`{job-name}.yaml`). The structure is:
    - `job_name`: the Prow job name
    - `build_errors`: list of build errors, each containing:
      - `job_url`: link to the Prow job UI
@@ -41,13 +42,19 @@ After data generation:
      - `category`: error category (external, internal, pr-build, needs-investigation)
      - `category_reason`: explanation of the categorization
      - `build_log_error_snippets`: list of error matches with `error_text`, `context`, and `link_to_log_line`
-3. For each failure, examine the `error_text` and `context` fields to determine the root cause
-4. Group failures with the same root cause together
+3. Read each k8s analysis YAML (`k8s-analysis-*.yaml`) if present. The structure is:
+   - `snapshots`: list of cluster state capture points (process + failure count)
+   - `findings`: list of detected issues with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
+   - `summary`: aggregate counts by kind, severity, and detector
+4. For each failure, examine build log errors AND k8s findings to determine the root cause
+5. Correlate k8s findings with build log errors — e.g. CrashLoopBackOff on a component pod often explains test timeouts
+6. Group failures with the same root cause together
 
 ## Output
 
 Present a concise summary to the user:
 - Group failures by root cause
 - For each group: state the root cause, list affected jobs, and include one representative error snippet
+- Include relevant k8s findings that explain or contribute to the failure
 - Classify each as **fixable** (CI config or code issue) or **non-fixable** (external/infra)
 - Include the `link_to_log_line` for the most relevant error in each group

--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -26,7 +26,7 @@ This command:
 3. Keeps only the latest run per job (jobs that eventually passed are excluded)
 4. Downloads build logs and extracts error snippets for each failure
 5. Writes one YAML file per failed job to `output/tmp/{job-name}.yaml`
-6. For each failed job, also downloads k8s-reporter artifacts and writes `output/tmp/k8s-analysis-{build-id}.yaml`
+6. For each failed job, also downloads k8s-reporter artifacts (and etcd profiler data if available) and writes `output/tmp/k8s-analysis-{build-id}.yaml`
 
 ## Analysis
 
@@ -46,8 +46,9 @@ After data generation:
    - `snapshots`: list of cluster state capture points (process + failure count)
    - `findings`: list of detected issues with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
    - `summary`: aggregate counts by kind, severity, and detector
+   - `etcd_profile` (optional): full etcd storage profile with peak/final tmpfs and WAL metrics, plus per-spec records. Etcd-related findings use kind `EtcdProfile` and detectors `etcd-tmpfs-exhaustion`, `etcd-tmpfs-pressure`, `etcd-large-wal`, `etcd-db-growth`
 4. For each failure, examine build log errors AND k8s findings to determine the root cause
-5. Correlate k8s findings with build log errors — e.g. CrashLoopBackOff on a component pod often explains test timeouts
+5. Correlate k8s findings with build log errors — e.g. CrashLoopBackOff on a component pod often explains test timeouts; etcd tmpfs exhaustion can explain apiserver or node-level failures
 6. Group failures with the same root cause together
 
 ## Output

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -88,6 +88,10 @@ artifacts directory in GCS, then runs failure detectors to identify issues like
 CrashLoopBackOff, OOMKilled, NotReady nodes, warning events, and failed VMI
 migrations.
 
+Also fetches etcd-storage-profile.json from artifacts/etcd-profiler/ when
+available (produced by runs with KUBEVIRT_PROFILE_ETCD=true) and detects etcd
+tmpfs exhaustion, tmpfs pressure, large WAL files, and DB growth trends.
+
 Accepts a Prow job URL, e.g.:
   https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17287/pull-kubevirt-e2e-k8s-1.31-sig-compute/2045831803410845696`,
 		Args: cobra.ExactArgs(1),

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -77,6 +77,22 @@ Only repos served by prow.ci.kubevirt.io are supported.`,
 		Args: cobra.ExactArgs(1),
 		RunE: analyzePR,
 	}
+
+	analyzeK8sCmd = &cobra.Command{
+		Use:   "analyze-k8s [prow-job-url]",
+		Short: "Analyze Kubernetes cluster state from k8s-reporter artifacts.",
+		Long: `Analyze Kubernetes cluster state from k8s-reporter artifacts for a Prow job.
+
+Downloads pods, nodes, events, and KubeVirt object dumps from the k8s-reporter
+artifacts directory in GCS, then runs failure detectors to identify issues like
+CrashLoopBackOff, OOMKilled, NotReady nodes, warning events, and failed VMI
+migrations.
+
+Accepts a Prow job URL, e.g.:
+  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17287/pull-kubevirt-e2e-k8s-1.31-sig-compute/2045831803410845696`,
+		Args: cobra.ExactArgs(1),
+		RunE: analyzeK8s,
+	}
 )
 
 func generateReport(cmd *cobra.Command, args []string) error {
@@ -204,6 +220,19 @@ func analyzeBuild(_ *cobra.Command, args []string) error {
 	}
 
 	log.Printf("wrote analysis to %s", outputPath)
+
+	k8sResult, k8sErr := cifailures.AnalyzeK8s(prowJobURL)
+	if k8sErr != nil {
+		log.WithError(k8sErr).Warn("k8s artifact analysis failed, skipping")
+	} else {
+		k8sOutputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("k8s-analysis-%d.yaml", k8sResult.BuildID))
+		if writeErr := cifailures.WriteK8sAnalysisResultYAML(k8sOutputPath, k8sResult); writeErr != nil {
+			log.WithError(writeErr).Warn("failed to write k8s analysis YAML")
+		} else {
+			log.Infof("wrote k8s analysis to %s (%d findings)", k8sOutputPath, k8sResult.Summary.TotalFindings)
+		}
+	}
+
 	return nil
 }
 
@@ -268,8 +297,41 @@ func analyzePR(_ *cobra.Command, args []string) error {
 		}
 
 		log.Infof("wrote analysis to %s", outputPath)
+
+		k8sResult, k8sErr := cifailures.AnalyzeK8s(url)
+		if k8sErr != nil {
+			log.WithError(k8sErr).Warnf("k8s artifact analysis failed for %s, skipping", url)
+		} else {
+			k8sOutputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("k8s-analysis-%d.yaml", k8sResult.BuildID))
+			if writeErr := cifailures.WriteK8sAnalysisResultYAML(k8sOutputPath, k8sResult); writeErr != nil {
+				log.WithError(writeErr).Warnf("failed to write k8s analysis YAML for %s", url)
+			} else {
+				log.Infof("wrote k8s analysis to %s (%d findings)", k8sOutputPath, k8sResult.Summary.TotalFindings)
+			}
+		}
 	}
 
+	return nil
+}
+
+func analyzeK8s(_ *cobra.Command, args []string) error {
+	prowJobURL := args[0]
+
+	result, err := cifailures.AnalyzeK8s(prowJobURL)
+	if err != nil {
+		return fmt.Errorf("failed to analyze k8s artifacts: %v", err)
+	}
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("k8s-analysis-%d.yaml", result.BuildID))
+	if err = cifailures.WriteK8sAnalysisResultYAML(outputPath, result); err != nil {
+		return fmt.Errorf("failed to write YAML output: %v", err)
+	}
+
+	log.Infof("wrote k8s analysis to %s (%d findings)", outputPath, result.Summary.TotalFindings)
 	return nil
 }
 
@@ -280,6 +342,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(analyzeBuildCmd)
 	rootCmd.AddCommand(analyzePRCmd)
+	rootCmd.AddCommand(analyzeK8sCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/ci-failures/k8s_analyze.go
+++ b/pkg/ci-failures/k8s_analyze.go
@@ -93,15 +93,22 @@ func AnalyzeK8s(prowJobURL string) (*K8sAnalysisResult, error) {
 		}
 	}
 
+	etcdProfile := fetchEtcdProfile(gcsBaseURL, cacheDir)
+	if etcdProfile != nil {
+		etcdFindings := detectEtcdIssues(etcdProfile)
+		allFindings = append(allFindings, etcdFindings...)
+	}
+
 	result := &K8sAnalysisResult{
-		ProwJobURL: prowJobURL,
-		JobName:    jobName,
-		BuildID:    buildID,
-		Started:    started,
-		Finished:   finished,
-		Snapshots:  snapshotList,
-		Findings:   allFindings,
-		Summary:    buildSummary(allFindings),
+		ProwJobURL:  prowJobURL,
+		JobName:     jobName,
+		BuildID:     buildID,
+		Started:     started,
+		Finished:    finished,
+		Snapshots:   snapshotList,
+		Findings:    allFindings,
+		Summary:     buildSummary(allFindings),
+		EtcdProfile: etcdProfile,
 	}
 
 	return result, nil
@@ -270,10 +277,41 @@ func parseAndDetect(raw []byte, artifactType string) []*K8sFinding {
 			return nil
 		}
 		return detectVMIMFailures(&vmims)
+	case "etcd-storage-profile":
+		var profile EtcdStorageProfile
+		if err := json.Unmarshal(raw, &profile); err != nil {
+			log.WithError(err).Warnf("failed to parse %s JSON", artifactType)
+			return nil
+		}
+		return detectEtcdIssues(&profile)
 	default:
 		log.Warnf("unknown artifact type: %s", artifactType)
 		return nil
 	}
+}
+
+func fetchEtcdProfile(gcsBaseURL, cacheDir string) *EtcdStorageProfile {
+	etcdURL := gcsBaseURL + "/artifacts/etcd-profiler/etcd-storage-profile.json"
+	if !probeExists(etcdURL) {
+		log.Info("no etcd-storage-profile.json found, skipping etcd analysis")
+		return nil
+	}
+
+	raw, err := downloadK8sArtifact(etcdURL, cacheDir, "etcd-storage-profile")
+	if err != nil {
+		log.WithError(err).Warn("failed to download etcd-storage-profile.json")
+		return nil
+	}
+
+	var profile EtcdStorageProfile
+	if err := json.Unmarshal(raw, &profile); err != nil {
+		log.WithError(err).Warn("failed to parse etcd-storage-profile.json")
+		return nil
+	}
+
+	log.Infof("loaded etcd profile: %d specs, peak tmpfs %d/%d bytes",
+		profile.TotalSpecs, profile.PeakTmpfsUsed, profile.FinalTmpfsTotal)
+	return &profile
 }
 
 func buildSummary(findings []*K8sFinding) K8sSummary {

--- a/pkg/ci-failures/k8s_analyze.go
+++ b/pkg/ci-failures/k8s_analyze.go
@@ -1,0 +1,307 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubevirt/ci-health/pkg/prow"
+	"github.com/kubevirt/ci-health/pkg/sigretests"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+const k8sArtifactsCacheDir = "output/tmp/k8s-artifacts"
+
+var k8sArtifactTypes = []string{
+	"pods",
+	"nodes",
+	"events",
+	"vmis",
+	"vmims",
+}
+
+// artifactSnapshot groups the GCS URLs for one cluster state snapshot.
+type artifactSnapshot struct {
+	snapshot K8sSnapshot
+	urls     map[string]string // artifactType -> GCS URL
+}
+
+// AnalyzeK8s downloads k8s-reporter artifacts for a prow job URL,
+// parses them, runs failure detectors, and returns the analysis result.
+func AnalyzeK8s(prowJobURL string) (*K8sAnalysisResult, error) {
+	prowJobURL = normalizeJobURL(prowJobURL)
+
+	gcsBaseURL := strings.Replace(prowJobURL,
+		"https://prow.ci.kubevirt.io/view/gs/",
+		"https://storage.googleapis.com/", 1)
+
+	jobName, err := jobNameFromURL(prowJobURL)
+	if err != nil {
+		return nil, err
+	}
+
+	buildID, err := buildIDFromJobURL(prowJobURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract build id: %v", err)
+	}
+
+	started, finished, err := fetchJobTimestamps(gcsBaseURL)
+	if err != nil {
+		log.WithError(err).Warn("failed to fetch job timestamps, continuing without them")
+	}
+
+	cacheDir := filepath.Join(k8sArtifactsCacheDir, fmt.Sprintf("%d", buildID))
+	if err = os.MkdirAll(cacheDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	snapshots := discoverAllSnapshots(gcsBaseURL)
+	if len(snapshots) == 0 {
+		return nil, fmt.Errorf("no k8s-reporter artifacts found at %s/artifacts/k8s-reporter/", gcsBaseURL)
+	}
+
+	var allFindings []*K8sFinding
+	var snapshotList []K8sSnapshot
+
+	for _, snap := range snapshots {
+		snapshotList = append(snapshotList, snap.snapshot)
+		snapCacheDir := filepath.Join(cacheDir, snap.snapshot.Process, fmt.Sprintf("%d", snap.snapshot.FailureCount))
+		if mkErr := os.MkdirAll(snapCacheDir, 0755); mkErr != nil {
+			log.WithError(mkErr).Warnf("failed to create snapshot cache dir, skipping %s", snap.snapshot)
+			continue
+		}
+
+		for artifactType, artifactURL := range snap.urls {
+			raw, dlErr := downloadK8sArtifact(artifactURL, snapCacheDir, artifactType)
+			if dlErr != nil {
+				log.WithError(dlErr).Warnf("failed to download %s for %s, skipping", artifactType, snap.snapshot)
+				continue
+			}
+
+			findings := parseAndDetect(raw, artifactType)
+			for _, f := range findings {
+				f.Snapshot = snap.snapshot
+			}
+			allFindings = append(allFindings, findings...)
+		}
+	}
+
+	result := &K8sAnalysisResult{
+		ProwJobURL: prowJobURL,
+		JobName:    jobName,
+		BuildID:    buildID,
+		Started:    started,
+		Finished:   finished,
+		Snapshots:  snapshotList,
+		Findings:   allFindings,
+		Summary:    buildSummary(allFindings),
+	}
+
+	return result, nil
+}
+
+func fetchJobTimestamps(gcsBaseURL string) (time.Time, time.Time, error) {
+	var zero time.Time
+
+	startedContent, err := retrieveFileContentFromGCS(gcsBaseURL + "/started.json")
+	if err != nil {
+		return zero, zero, fmt.Errorf("failed to fetch started.json: %v", err)
+	}
+	var started prow.Started
+	if err = json.Unmarshal(startedContent, &started); err != nil {
+		return zero, zero, fmt.Errorf("failed to decode started.json: %v", err)
+	}
+
+	finishedContent, err := retrieveFileContentFromGCS(gcsBaseURL + "/finished.json")
+	if err != nil {
+		return zero, zero, fmt.Errorf("failed to fetch finished.json: %v", err)
+	}
+	var finished prow.Finished
+	if err = json.Unmarshal(finishedContent, &finished); err != nil {
+		return zero, zero, fmt.Errorf("failed to decode finished.json: %v", err)
+	}
+
+	return started.Time(), finished.Time(), nil
+}
+
+// discoverAllSnapshots finds all cluster state snapshots across all parallel
+// processes and failure counts. The artifact layout is:
+//
+//	k8s-reporter/{process}/{failureCount}_{type}.log  (parallel runs)
+//	k8s-reporter/{failureCount}_{type}.log            (non-parallel runs)
+//	k8s-reporter/suite/{failureCount}_{type}.log      (suite-level dump)
+func discoverAllSnapshots(gcsBaseURL string) []artifactSnapshot {
+	k8sReporterBase := gcsBaseURL + "/artifacts/k8s-reporter"
+
+	// Discover which base paths have artifacts.
+	type basePath struct {
+		path    string
+		process string // "1", "2", ..., "suite", or "flat"
+	}
+	var activePaths []basePath
+
+	// Check parallel processes 1-12
+	for p := 1; p <= 12; p++ {
+		path := fmt.Sprintf("%s/%d", k8sReporterBase, p)
+		if probeExists(fmt.Sprintf("%s/1_pods.log", path)) {
+			activePaths = append(activePaths, basePath{path: path, process: fmt.Sprintf("%d", p)})
+		}
+	}
+
+	// Check suite path
+	suitePath := k8sReporterBase + "/suite"
+	if probeExists(fmt.Sprintf("%s/0_pods.log", suitePath)) {
+		activePaths = append(activePaths, basePath{path: suitePath, process: "suite"})
+	}
+
+	// Check flat path (non-parallel)
+	if len(activePaths) == 0 {
+		if probeExists(fmt.Sprintf("%s/1_pods.log", k8sReporterBase)) {
+			activePaths = append(activePaths, basePath{path: k8sReporterBase, process: "flat"})
+		}
+	}
+
+	if len(activePaths) == 0 {
+		return nil
+	}
+
+	// For each active path, discover all failure counts.
+	var result []artifactSnapshot
+
+	for _, bp := range activePaths {
+		startN := 1
+		if bp.process == "suite" {
+			startN = 0
+		}
+
+		for n := startN; n <= 20; n++ {
+			urls := map[string]string{}
+			for _, artifactType := range k8sArtifactTypes {
+				url := fmt.Sprintf("%s/%d_%s.log", bp.path, n, artifactType)
+				if probeExists(url) {
+					urls[artifactType] = url
+				}
+			}
+			if len(urls) == 0 {
+				break
+			}
+			snap := artifactSnapshot{
+				snapshot: K8sSnapshot{Process: bp.process, FailureCount: n},
+				urls:     urls,
+			}
+			log.Infof("discovered snapshot %s with %d artifact types", snap.snapshot, len(urls))
+			result = append(result, snap)
+		}
+	}
+
+	return result
+}
+
+func probeExists(url string) bool {
+	resp, err := sigretests.HttpHeadWithRetry(url)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func downloadK8sArtifact(gcsURL, cacheDir, artifactType string) ([]byte, error) {
+	cachePath := filepath.Join(cacheDir, artifactType+".json")
+
+	_, err := os.Stat(cachePath)
+	if !errors.Is(err, fs.ErrNotExist) {
+		return os.ReadFile(cachePath)
+	}
+
+	raw, err := retrieveFileContentFromGCS(gcsURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if writeErr := os.WriteFile(cachePath, raw, 0644); writeErr != nil {
+		log.WithError(writeErr).Warnf("failed to cache %s artifact", artifactType)
+	}
+
+	return raw, nil
+}
+
+func parseAndDetect(raw []byte, artifactType string) []*K8sFinding {
+	switch artifactType {
+	case "pods":
+		var pods K8sPodList
+		if err := json.Unmarshal(raw, &pods); err != nil {
+			log.WithError(err).Warnf("failed to parse %s JSON", artifactType)
+			return nil
+		}
+		return detectPodFailures(&pods)
+	case "nodes":
+		var nodes K8sNodeList
+		if err := json.Unmarshal(raw, &nodes); err != nil {
+			log.WithError(err).Warnf("failed to parse %s JSON", artifactType)
+			return nil
+		}
+		return detectNodeFailures(&nodes)
+	case "events":
+		var events K8sEventList
+		if err := json.Unmarshal(raw, &events); err != nil {
+			log.WithError(err).Warnf("failed to parse %s JSON", artifactType)
+			return nil
+		}
+		return detectEventFailures(&events)
+	case "vmis":
+		var vmis K8sVMIList
+		if err := json.Unmarshal(raw, &vmis); err != nil {
+			log.WithError(err).Warnf("failed to parse %s JSON", artifactType)
+			return nil
+		}
+		return detectVMIFailures(&vmis)
+	case "vmims":
+		var vmims K8sVMIMList
+		if err := json.Unmarshal(raw, &vmims); err != nil {
+			log.WithError(err).Warnf("failed to parse %s JSON", artifactType)
+			return nil
+		}
+		return detectVMIMFailures(&vmims)
+	default:
+		log.Warnf("unknown artifact type: %s", artifactType)
+		return nil
+	}
+}
+
+func buildSummary(findings []*K8sFinding) K8sSummary {
+	summary := K8sSummary{
+		TotalFindings: len(findings),
+		ByKind:        map[string]int{},
+		BySeverity:    map[string]int{},
+		ByDetector:    map[string]int{},
+	}
+	for _, f := range findings {
+		summary.ByKind[f.Kind]++
+		summary.BySeverity[f.Severity]++
+		summary.ByDetector[f.Detector]++
+	}
+	return summary
+}
+
+// WriteK8sAnalysisResultYAML writes the analysis result to a file in YAML format.
+func WriteK8sAnalysisResultYAML(outputPath string, result *K8sAnalysisResult) error {
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
+	}
+	defer outputFile.Close()
+
+	encoder := yaml.NewEncoder(outputFile)
+	if err := encoder.Encode(result); err != nil {
+		return fmt.Errorf("failed to encode YAML: %v", err)
+	}
+	return nil
+}

--- a/pkg/ci-failures/k8s_analyze_test.go
+++ b/pkg/ci-failures/k8s_analyze_test.go
@@ -1,0 +1,402 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseAndDetect(t *testing.T) {
+	tests := []struct {
+		name          string
+		artifactType  string
+		json          string
+		expectedCount int
+	}{
+		{
+			name:         "pods with CrashLoopBackOff",
+			artifactType: "pods",
+			json: `{
+				"items": [{
+					"metadata": {"name": "test-pod", "namespace": "default"},
+					"spec": {},
+					"status": {
+						"phase": "Running",
+						"containerStatuses": [{
+							"name": "app",
+							"ready": false,
+							"restartCount": 8,
+							"state": {
+								"waiting": {"reason": "CrashLoopBackOff"}
+							}
+						}]
+					}
+				}]
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:         "nodes all healthy",
+			artifactType: "nodes",
+			json: `{
+				"items": [{
+					"metadata": {"name": "node1"},
+					"status": {
+						"conditions": [
+							{"type": "Ready", "status": "True"},
+							{"type": "DiskPressure", "status": "False"}
+						]
+					}
+				}]
+			}`,
+			expectedCount: 0,
+		},
+		{
+			name:         "events with warnings",
+			artifactType: "events",
+			json: `{
+				"items": [{
+					"metadata": {"name": "ev1"},
+					"involvedObject": {"kind": "Pod", "name": "test", "namespace": "ns"},
+					"type": "Warning",
+					"reason": "FailedScheduling",
+					"message": "0/3 nodes available",
+					"count": 3
+				}]
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:         "vmis with failed phase",
+			artifactType: "vmis",
+			json: `{
+				"items": [{
+					"metadata": {"name": "vmi1", "namespace": "ns"},
+					"status": {"phase": "Failed"}
+				}]
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:          "vmims empty",
+			artifactType:  "vmims",
+			json:          `{"items": []}`,
+			expectedCount: 0,
+		},
+		{
+			name:          "unknown type returns nil",
+			artifactType:  "unknown",
+			json:          `{}`,
+			expectedCount: 0,
+		},
+		{
+			name:          "invalid JSON returns nil",
+			artifactType:  "pods",
+			json:          `{invalid`,
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := parseAndDetect([]byte(tt.json), tt.artifactType)
+			if len(findings) != tt.expectedCount {
+				t.Errorf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+		})
+	}
+}
+
+func TestDiscoverAllSnapshotsFlatPath(t *testing.T) {
+	mux := http.NewServeMux()
+	// Non-parallel run: artifacts directly under k8s-reporter/
+	mux.HandleFunc("/artifacts/k8s-reporter/1_pods.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1_nodes.log", ok)
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	snapshots := discoverAllSnapshots(server.URL)
+
+	if len(snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snapshots))
+	}
+	if snapshots[0].snapshot.Process != "flat" {
+		t.Errorf("expected process 'flat', got %q", snapshots[0].snapshot.Process)
+	}
+	if snapshots[0].snapshot.FailureCount != 1 {
+		t.Errorf("expected failureCount 1, got %d", snapshots[0].snapshot.FailureCount)
+	}
+	if len(snapshots[0].urls) != 2 {
+		t.Errorf("expected 2 artifact URLs, got %d", len(snapshots[0].urls))
+	}
+}
+
+func TestDiscoverAllSnapshotsParallelSingleFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_pods.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_nodes.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_events.log", ok)
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	snapshots := discoverAllSnapshots(server.URL)
+
+	if len(snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snapshots))
+	}
+	if snapshots[0].snapshot.Process != "1" {
+		t.Errorf("expected process '1', got %q", snapshots[0].snapshot.Process)
+	}
+	if len(snapshots[0].urls) != 3 {
+		t.Errorf("expected 3 artifacts, got %d", len(snapshots[0].urls))
+	}
+}
+
+func TestDiscoverAllSnapshotsMultipleFailures(t *testing.T) {
+	mux := http.NewServeMux()
+	// Process 1, failures 1-3
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_pods.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_nodes.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/2_pods.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/2_nodes.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/3_pods.log", ok)
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	snapshots := discoverAllSnapshots(server.URL)
+
+	if len(snapshots) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+	}
+	for i, expected := range []int{1, 2, 3} {
+		if snapshots[i].snapshot.FailureCount != expected {
+			t.Errorf("snapshot %d: expected failureCount %d, got %d", i, expected, snapshots[i].snapshot.FailureCount)
+		}
+	}
+}
+
+func TestDiscoverAllSnapshotsMultipleProcesses(t *testing.T) {
+	mux := http.NewServeMux()
+	// Process 1: 2 failures
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_pods.log", ok)
+	mux.HandleFunc("/artifacts/k8s-reporter/1/2_pods.log", ok)
+	// Process 4: 1 failure
+	mux.HandleFunc("/artifacts/k8s-reporter/4/1_pods.log", ok)
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	snapshots := discoverAllSnapshots(server.URL)
+
+	if len(snapshots) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+	}
+
+	// Process 1 should come first (lower process number)
+	if snapshots[0].snapshot.Process != "1" || snapshots[0].snapshot.FailureCount != 1 {
+		t.Errorf("expected process=1/failure=1, got %s", snapshots[0].snapshot)
+	}
+	if snapshots[1].snapshot.Process != "1" || snapshots[1].snapshot.FailureCount != 2 {
+		t.Errorf("expected process=1/failure=2, got %s", snapshots[1].snapshot)
+	}
+	if snapshots[2].snapshot.Process != "4" || snapshots[2].snapshot.FailureCount != 1 {
+		t.Errorf("expected process=4/failure=1, got %s", snapshots[2].snapshot)
+	}
+}
+
+func TestDiscoverAllSnapshotsSuiteAndParallel(t *testing.T) {
+	mux := http.NewServeMux()
+	// Process 1
+	mux.HandleFunc("/artifacts/k8s-reporter/1/1_pods.log", ok)
+	// Suite (uses failureCount 0)
+	mux.HandleFunc("/artifacts/k8s-reporter/suite/0_pods.log", ok)
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	snapshots := discoverAllSnapshots(server.URL)
+
+	if len(snapshots) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snapshots))
+	}
+
+	processes := map[string]bool{}
+	for _, s := range snapshots {
+		processes[s.snapshot.Process] = true
+	}
+	if !processes["1"] {
+		t.Error("expected process '1'")
+	}
+	if !processes["suite"] {
+		t.Error("expected process 'suite'")
+	}
+}
+
+func TestDownloadK8sArtifactCaching(t *testing.T) {
+	callCount := 0
+	podJSON := `{"items": []}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		fmt.Fprint(w, podJSON)
+	}))
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+
+	raw1, err := downloadK8sArtifact(server.URL+"/pods.log", cacheDir, "pods")
+	if err != nil {
+		t.Fatalf("first download failed: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", callCount)
+	}
+
+	raw2, err := downloadK8sArtifact(server.URL+"/pods.log", cacheDir, "pods")
+	if err != nil {
+		t.Fatalf("second download failed: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected cache hit (still 1 HTTP call), got %d", callCount)
+	}
+
+	if string(raw1) != string(raw2) {
+		t.Error("cached content differs from original")
+	}
+
+	cached, err := os.ReadFile(filepath.Join(cacheDir, "pods.json"))
+	if err != nil {
+		t.Fatalf("cache file not found: %v", err)
+	}
+	if string(cached) != podJSON {
+		t.Errorf("cache file content mismatch: got %q", string(cached))
+	}
+}
+
+func TestBuildSummary(t *testing.T) {
+	findings := []*K8sFinding{
+		{Detector: "pod-crash-loop", Severity: "error", Kind: "Pod"},
+		{Detector: "pod-crash-loop", Severity: "error", Kind: "Pod"},
+		{Detector: "node-not-ready", Severity: "error", Kind: "Node"},
+		{Detector: "event-warning", Severity: "warning", Kind: "Event"},
+	}
+
+	s := buildSummary(findings)
+
+	if s.TotalFindings != 4 {
+		t.Errorf("expected 4 total, got %d", s.TotalFindings)
+	}
+	if s.ByKind["Pod"] != 2 {
+		t.Errorf("expected 2 pods, got %d", s.ByKind["Pod"])
+	}
+	if s.ByKind["Node"] != 1 {
+		t.Errorf("expected 1 node, got %d", s.ByKind["Node"])
+	}
+	if s.BySeverity["error"] != 3 {
+		t.Errorf("expected 3 errors, got %d", s.BySeverity["error"])
+	}
+	if s.BySeverity["warning"] != 1 {
+		t.Errorf("expected 1 warning, got %d", s.BySeverity["warning"])
+	}
+	if s.ByDetector["pod-crash-loop"] != 2 {
+		t.Errorf("expected 2 pod-crash-loop, got %d", s.ByDetector["pod-crash-loop"])
+	}
+}
+
+func TestWriteK8sAnalysisResultYAML(t *testing.T) {
+	result := &K8sAnalysisResult{
+		ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/test",
+		JobName:    "test-job",
+		BuildID:    12345,
+		Snapshots:  []K8sSnapshot{{Process: "1", FailureCount: 1}},
+		Findings: []*K8sFinding{{
+			Detector: "pod-crash-loop",
+			Severity: "error",
+			Kind:     "Pod",
+			Name:     "test-pod",
+			Reason:   "CrashLoopBackOff",
+			Message:  "Container app in CrashLoopBackOff",
+			Snapshot: K8sSnapshot{Process: "1", FailureCount: 1},
+		}},
+		Summary: buildSummary([]*K8sFinding{{
+			Detector: "pod-crash-loop",
+			Severity: "error",
+			Kind:     "Pod",
+		}}),
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "test-output.yaml")
+	if err := WriteK8sAnalysisResultYAML(outputPath, result); err != nil {
+		t.Fatalf("failed to write YAML: %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	yamlStr := string(content)
+	for _, expected := range []string{"prow_job_url:", "pod-crash-loop", "CrashLoopBackOff", "test-pod", "process:", "failure_count:"} {
+		if !strings.Contains(yamlStr, expected) {
+			t.Errorf("YAML output missing %q", expected)
+		}
+	}
+}
+
+func TestFetchJobTimestamps(t *testing.T) {
+	started := map[string]any{"timestamp": 1713520103}
+	finished := map[string]any{"timestamp": 1713521809, "passed": false, "result": "FAILURE"}
+
+	startedJSON, _ := json.Marshal(started)
+	finishedJSON, _ := json.Marshal(finished)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/started.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(startedJSON)
+	})
+	mux.HandleFunc("/finished.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(finishedJSON)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	s, f, err := fetchJobTimestamps(server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Unix() != 1713520103 {
+		t.Errorf("started timestamp mismatch: got %d", s.Unix())
+	}
+	if f.Unix() != 1713521809 {
+		t.Errorf("finished timestamp mismatch: got %d", f.Unix())
+	}
+}
+
+func TestK8sSnapshotString(t *testing.T) {
+	s := K8sSnapshot{Process: "1", FailureCount: 3}
+	if s.String() != "process=1/failure=3" {
+		t.Errorf("unexpected String(): %q", s.String())
+	}
+}
+
+func ok(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func notFound(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+}

--- a/pkg/ci-failures/k8s_analyze_test.go
+++ b/pkg/ci-failures/k8s_analyze_test.go
@@ -89,6 +89,23 @@ func TestParseAndDetect(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
+			name:         "etcd-storage-profile with tmpfs exhaustion",
+			artifactType: "etcd-storage-profile",
+			json: `{
+				"collectedAt": "2026-03-05T18:30:39Z",
+				"totalSpecs": 2,
+				"finalDBSizeBytes": 10000000,
+				"finalTmpfsUsedBytes": 480000000,
+				"finalTmpfsTotalBytes": 512000000,
+				"finalWALSizeBytes": 50000000,
+				"finalSnapSizeBytes": 10000000,
+				"peakTmpfsUsedBytes": 480000000,
+				"peakDBSizeBytes": 10000000,
+				"records": []
+			}`,
+			expectedCount: 1,
+		},
+		{
 			name:          "unknown type returns nil",
 			artifactType:  "unknown",
 			json:          `{}`,
@@ -390,6 +407,65 @@ func TestK8sSnapshotString(t *testing.T) {
 	s := K8sSnapshot{Process: "1", FailureCount: 3}
 	if s.String() != "process=1/failure=3" {
 		t.Errorf("unexpected String(): %q", s.String())
+	}
+}
+
+func TestFetchEtcdProfile(t *testing.T) {
+	profileJSON := `{
+		"collectedAt": "2026-03-05T18:30:39Z",
+		"totalSpecs": 5,
+		"finalDBSizeBytes": 10000000,
+		"finalTmpfsUsedBytes": 200000000,
+		"finalTmpfsTotalBytes": 536870912,
+		"finalWALSizeBytes": 50000000,
+		"finalSnapSizeBytes": 10000000,
+		"peakTmpfsUsedBytes": 450000000,
+		"peakDBSizeBytes": 12000000,
+		"records": []
+	}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/artifacts/etcd-profiler/etcd-storage-profile.json", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		fmt.Fprint(w, profileJSON)
+	})
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	profile := fetchEtcdProfile(server.URL, cacheDir)
+
+	if profile == nil {
+		t.Fatal("expected non-nil profile")
+	}
+	if profile.TotalSpecs != 5 {
+		t.Errorf("expected 5 specs, got %d", profile.TotalSpecs)
+	}
+	if profile.PeakTmpfsUsed != 450000000 {
+		t.Errorf("expected peak tmpfs 450000000, got %d", profile.PeakTmpfsUsed)
+	}
+	if profile.FinalTmpfsTotal != 536870912 {
+		t.Errorf("expected tmpfs total 536870912, got %d", profile.FinalTmpfsTotal)
+	}
+}
+
+func TestFetchEtcdProfileNotPresent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	profile := fetchEtcdProfile(server.URL, cacheDir)
+
+	if profile != nil {
+		t.Errorf("expected nil profile when not present, got %+v", profile)
 	}
 }
 

--- a/pkg/ci-failures/k8s_detectors.go
+++ b/pkg/ci-failures/k8s_detectors.go
@@ -296,6 +296,68 @@ func detectVMIFailures(vmis *K8sVMIList) []*K8sFinding {
 	return findings
 }
 
+func detectEtcdIssues(profile *EtcdStorageProfile) []*K8sFinding {
+	if profile == nil {
+		return nil
+	}
+	var findings []*K8sFinding
+
+	if profile.FinalTmpfsTotal > 0 {
+		usagePct := float64(profile.PeakTmpfsUsed) / float64(profile.FinalTmpfsTotal) * 100
+
+		if usagePct > 90 {
+			findings = append(findings, &K8sFinding{
+				Detector: "etcd-tmpfs-exhaustion",
+				Severity: "error",
+				Kind:     "EtcdProfile",
+				Name:     "etcd",
+				Reason:   "TmpfsExhaustion",
+				Message:  fmt.Sprintf("Peak tmpfs usage %.1f%% (%d/%d bytes)", usagePct, profile.PeakTmpfsUsed, profile.FinalTmpfsTotal),
+			})
+		} else if usagePct > 75 {
+			findings = append(findings, &K8sFinding{
+				Detector: "etcd-tmpfs-pressure",
+				Severity: "warning",
+				Kind:     "EtcdProfile",
+				Name:     "etcd",
+				Reason:   "TmpfsPressure",
+				Message:  fmt.Sprintf("Peak tmpfs usage %.1f%% (%d/%d bytes)", usagePct, profile.PeakTmpfsUsed, profile.FinalTmpfsTotal),
+			})
+		}
+
+		walPct := float64(profile.FinalWALSize) / float64(profile.FinalTmpfsTotal) * 100
+		if walPct > 50 {
+			findings = append(findings, &K8sFinding{
+				Detector: "etcd-large-wal",
+				Severity: "warning",
+				Kind:     "EtcdProfile",
+				Name:     "etcd",
+				Reason:   "LargeWAL",
+				Message:  fmt.Sprintf("WAL consuming %.1f%% of tmpfs (%d/%d bytes)", walPct, profile.FinalWALSize, profile.FinalTmpfsTotal),
+			})
+		}
+	}
+
+	var totalDBGrowth int64
+	for _, r := range profile.Records {
+		if r.DeltaDBSize > 0 {
+			totalDBGrowth += r.DeltaDBSize
+		}
+	}
+	if totalDBGrowth > 0 {
+		findings = append(findings, &K8sFinding{
+			Detector: "etcd-db-growth",
+			Severity: "info",
+			Kind:     "EtcdProfile",
+			Name:     "etcd",
+			Reason:   "DBGrowth",
+			Message:  fmt.Sprintf("Total DB growth across %d specs: %d bytes", profile.TotalSpecs, totalDBGrowth),
+		})
+	}
+
+	return findings
+}
+
 func detectVMIMFailures(vmims *K8sVMIMList) []*K8sFinding {
 	if vmims == nil {
 		return nil

--- a/pkg/ci-failures/k8s_detectors.go
+++ b/pkg/ci-failures/k8s_detectors.go
@@ -1,0 +1,320 @@
+package cifailures
+
+import "fmt"
+
+var criticalEventReasons = map[string]bool{
+	"FailedScheduling": true,
+	"FailedMount":      true,
+	"FailedCreate":     true,
+	"Unhealthy":        true,
+	"BackOff":          true,
+	"Evicted":          true,
+	"OOMKilling":       true,
+	"FailedSync":       true,
+	"NodeNotReady":     true,
+}
+
+func detectPodFailures(pods *K8sPodList) []*K8sFinding {
+	if pods == nil {
+		return nil
+	}
+	var findings []*K8sFinding
+
+	for _, pod := range pods.Items {
+		// Evicted pods
+		if pod.Status.Phase == "Failed" && pod.Status.Reason == "Evicted" {
+			findings = append(findings, &K8sFinding{
+				Detector:  "pod-evicted",
+				Severity:  "warning",
+				Kind:      "Pod",
+				Namespace: pod.Metadata.Namespace,
+				Name:      pod.Metadata.Name,
+				Reason:    "Evicted",
+				Message:   pod.Status.Message,
+			})
+			continue
+		}
+
+		// Container statuses
+		for _, cs := range pod.Status.ContainerStatuses {
+			findings = append(findings, detectContainerIssues(&pod, &cs, "container")...)
+		}
+
+		// Init container statuses
+		for _, cs := range pod.Status.InitContainerStatuses {
+			findings = append(findings, detectContainerIssues(&pod, &cs, "init-container")...)
+		}
+
+		// Pending + Unschedulable
+		if pod.Status.Phase == "Pending" {
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == "PodScheduled" && cond.Status == "False" {
+					findings = append(findings, &K8sFinding{
+						Detector:  "pod-unschedulable",
+						Severity:  "error",
+						Kind:      "Pod",
+						Namespace: pod.Metadata.Namespace,
+						Name:      pod.Metadata.Name,
+						Reason:    cond.Reason,
+						Message:   fmt.Sprintf("Pod stuck in Pending: %s", cond.Message),
+					})
+				}
+			}
+		}
+	}
+
+	return findings
+}
+
+func detectContainerIssues(pod *K8sPod, cs *K8sContainerStatus, containerType string) []*K8sFinding {
+	var findings []*K8sFinding
+
+	if cs.State.Waiting != nil {
+		switch cs.State.Waiting.Reason {
+		case "CrashLoopBackOff":
+			findings = append(findings, &K8sFinding{
+				Detector:  "pod-crash-loop",
+				Severity:  "error",
+				Kind:      "Pod",
+				Namespace: pod.Metadata.Namespace,
+				Name:      pod.Metadata.Name,
+				Reason:    "CrashLoopBackOff",
+				Message:   fmt.Sprintf("Container %s in CrashLoopBackOff (%d restarts)", cs.Name, cs.RestartCount),
+			})
+		case "ImagePullBackOff", "ErrImagePull":
+			findings = append(findings, &K8sFinding{
+				Detector:  "pod-image-pull",
+				Severity:  "error",
+				Kind:      "Pod",
+				Namespace: pod.Metadata.Namespace,
+				Name:      pod.Metadata.Name,
+				Reason:    cs.State.Waiting.Reason,
+				Message:   fmt.Sprintf("Container %s: %s", cs.Name, cs.State.Waiting.Message),
+			})
+		}
+	}
+
+	if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+		findings = append(findings, &K8sFinding{
+			Detector:  "pod-oom-killed",
+			Severity:  "error",
+			Kind:      "Pod",
+			Namespace: pod.Metadata.Namespace,
+			Name:      pod.Metadata.Name,
+			Reason:    "OOMKilled",
+			Message:   fmt.Sprintf("Container %s was OOMKilled (exit code %d)", cs.Name, cs.LastTerminationState.Terminated.ExitCode),
+		})
+	}
+
+	if containerType == "init-container" && cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+		findings = append(findings, &K8sFinding{
+			Detector:  "pod-init-failure",
+			Severity:  "error",
+			Kind:      "Pod",
+			Namespace: pod.Metadata.Namespace,
+			Name:      pod.Metadata.Name,
+			Reason:    fmt.Sprintf("InitContainerFailed:%s", cs.Name),
+			Message:   fmt.Sprintf("Init container %s exited with code %d", cs.Name, cs.State.Terminated.ExitCode),
+		})
+	}
+
+	if cs.RestartCount > 5 && cs.State.Waiting == nil {
+		findings = append(findings, &K8sFinding{
+			Detector:  "pod-high-restarts",
+			Severity:  "warning",
+			Kind:      "Pod",
+			Namespace: pod.Metadata.Namespace,
+			Name:      pod.Metadata.Name,
+			Reason:    "HighRestartCount",
+			Message:   fmt.Sprintf("Container %s has %d restarts", cs.Name, cs.RestartCount),
+		})
+	}
+
+	if pod.Status.Phase == "Running" && !cs.Ready && cs.State.Waiting == nil {
+		findings = append(findings, &K8sFinding{
+			Detector:  "pod-not-ready",
+			Severity:  "warning",
+			Kind:      "Pod",
+			Namespace: pod.Metadata.Namespace,
+			Name:      pod.Metadata.Name,
+			Reason:    "ContainerNotReady",
+			Message:   fmt.Sprintf("Container %s is not ready", cs.Name),
+		})
+	}
+
+	return findings
+}
+
+func detectNodeFailures(nodes *K8sNodeList) []*K8sFinding {
+	if nodes == nil {
+		return nil
+	}
+	var findings []*K8sFinding
+
+	for _, node := range nodes.Items {
+		for _, cond := range node.Status.Conditions {
+			switch cond.Type {
+			case "Ready":
+				if cond.Status == "False" {
+					findings = append(findings, &K8sFinding{
+						Detector: "node-not-ready",
+						Severity: "error",
+						Kind:     "Node",
+						Name:     node.Metadata.Name,
+						Reason:   cond.Reason,
+						Message:  fmt.Sprintf("Node condition Ready is False: %s", cond.Message),
+					})
+				}
+			case "DiskPressure", "MemoryPressure", "PIDPressure":
+				if cond.Status == "True" {
+					findings = append(findings, &K8sFinding{
+						Detector: "node-pressure",
+						Severity: "error",
+						Kind:     "Node",
+						Name:     node.Metadata.Name,
+						Reason:   cond.Type,
+						Message:  fmt.Sprintf("Node has %s: %s", cond.Type, cond.Message),
+					})
+				}
+			case "NetworkUnavailable":
+				if cond.Status == "True" {
+					findings = append(findings, &K8sFinding{
+						Detector: "node-network-unavailable",
+						Severity: "warning",
+						Kind:     "Node",
+						Name:     node.Metadata.Name,
+						Reason:   cond.Reason,
+						Message:  fmt.Sprintf("Node network unavailable: %s", cond.Message),
+					})
+				}
+			}
+		}
+	}
+
+	return findings
+}
+
+func detectEventFailures(events *K8sEventList) []*K8sFinding {
+	if events == nil {
+		return nil
+	}
+
+	type eventGroup struct {
+		count          int
+		sampleMessage  string
+		involvedObject K8sObjectReference
+	}
+	grouped := map[string]*eventGroup{}
+
+	for _, event := range events.Items {
+		if event.Type != "Warning" {
+			continue
+		}
+		g, exists := grouped[event.Reason]
+		if !exists {
+			g = &eventGroup{
+				sampleMessage:  event.Message,
+				involvedObject: event.InvolvedObject,
+			}
+			grouped[event.Reason] = g
+		}
+		g.count += max(event.Count, 1)
+	}
+
+	var findings []*K8sFinding
+	for reason, g := range grouped {
+		severity := "warning"
+		if criticalEventReasons[reason] {
+			severity = "error"
+		}
+		findings = append(findings, &K8sFinding{
+			Detector:  "event-warning",
+			Severity:  severity,
+			Kind:      "Event",
+			Namespace: g.involvedObject.Namespace,
+			Name:      g.involvedObject.Name,
+			Reason:    reason,
+			Message:   fmt.Sprintf("%d warning event(s) with reason %s", g.count, reason),
+			Detail:    g.sampleMessage,
+		})
+	}
+
+	return findings
+}
+
+func detectVMIFailures(vmis *K8sVMIList) []*K8sFinding {
+	if vmis == nil {
+		return nil
+	}
+	var findings []*K8sFinding
+
+	for _, vmi := range vmis.Items {
+		if vmi.Status.Phase != "Running" && vmi.Status.Phase != "Succeeded" && vmi.Status.Phase != "" {
+			severity := "warning"
+			if vmi.Status.Phase == "Failed" {
+				severity = "error"
+			}
+			findings = append(findings, &K8sFinding{
+				Detector:  "vmi-not-running",
+				Severity:  severity,
+				Kind:      "VMI",
+				Namespace: vmi.Metadata.Namespace,
+				Name:      vmi.Metadata.Name,
+				Reason:    vmi.Status.Phase,
+				Message:   fmt.Sprintf("VMI phase is %s", vmi.Status.Phase),
+			})
+		}
+
+		if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.Failed {
+			findings = append(findings, &K8sFinding{
+				Detector:  "vmi-migration-failed",
+				Severity:  "error",
+				Kind:      "VMI",
+				Namespace: vmi.Metadata.Namespace,
+				Name:      vmi.Metadata.Name,
+				Reason:    "MigrationFailed",
+				Message: fmt.Sprintf("VMI migration failed (source: %s, target: %s)",
+					vmi.Status.MigrationState.SourceNodeName, vmi.Status.MigrationState.TargetNodeName),
+			})
+		}
+
+		for _, cond := range vmi.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == "False" {
+				findings = append(findings, &K8sFinding{
+					Detector:  "vmi-not-ready",
+					Severity:  "warning",
+					Kind:      "VMI",
+					Namespace: vmi.Metadata.Namespace,
+					Name:      vmi.Metadata.Name,
+					Reason:    cond.Reason,
+					Message:   fmt.Sprintf("VMI not ready: %s", cond.Message),
+				})
+			}
+		}
+	}
+
+	return findings
+}
+
+func detectVMIMFailures(vmims *K8sVMIMList) []*K8sFinding {
+	if vmims == nil {
+		return nil
+	}
+	var findings []*K8sFinding
+
+	for _, vmim := range vmims.Items {
+		if vmim.Status.Phase == "Failed" {
+			findings = append(findings, &K8sFinding{
+				Detector:  "vmim-failed",
+				Severity:  "error",
+				Kind:      "VMIM",
+				Namespace: vmim.Metadata.Namespace,
+				Name:      vmim.Metadata.Name,
+				Reason:    "Failed",
+				Message:   "VirtualMachineInstanceMigration failed",
+			})
+		}
+	}
+
+	return findings
+}

--- a/pkg/ci-failures/k8s_detectors_test.go
+++ b/pkg/ci-failures/k8s_detectors_test.go
@@ -1,0 +1,552 @@
+package cifailures
+
+import (
+	"testing"
+)
+
+func TestDetectPodFailures(t *testing.T) {
+	tests := []struct {
+		name             string
+		pods             *K8sPodList
+		expectedCount    int
+		expectedDetector string
+		expectedReason   string
+	}{
+		{
+			name:          "nil pods",
+			pods:          nil,
+			expectedCount: 0,
+		},
+		{
+			name:          "empty pod list",
+			pods:          &K8sPodList{},
+			expectedCount: 0,
+		},
+		{
+			name: "healthy pod",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Status: K8sPodStatus{
+					Phase: "Running",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name:  "app",
+						Ready: true,
+					}},
+				},
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "CrashLoopBackOff",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "test-pod", Namespace: "default"},
+				Status: K8sPodStatus{
+					Phase: "Running",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name:         "app",
+						RestartCount: 12,
+						State: K8sContainerState{
+							Waiting: &K8sContainerStateWaiting{Reason: "CrashLoopBackOff"},
+						},
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-crash-loop",
+			expectedReason:   "CrashLoopBackOff",
+		},
+		{
+			name: "OOMKilled",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "oom-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Running",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name:  "app",
+						Ready: true,
+						LastTerminationState: K8sContainerState{
+							Terminated: &K8sContainerStateTerminated{
+								Reason:   "OOMKilled",
+								ExitCode: 137,
+							},
+						},
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-oom-killed",
+			expectedReason:   "OOMKilled",
+		},
+		{
+			name: "ImagePullBackOff",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "img-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Pending",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name: "app",
+						State: K8sContainerState{
+							Waiting: &K8sContainerStateWaiting{
+								Reason:  "ImagePullBackOff",
+								Message: "Back-off pulling image",
+							},
+						},
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-image-pull",
+			expectedReason:   "ImagePullBackOff",
+		},
+		{
+			name: "ErrImagePull",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "img-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Pending",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name: "app",
+						State: K8sContainerState{
+							Waiting: &K8sContainerStateWaiting{Reason: "ErrImagePull"},
+						},
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-image-pull",
+			expectedReason:   "ErrImagePull",
+		},
+		{
+			name: "Pending unschedulable",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "pending-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Pending",
+					Conditions: []K8sPodCondition{{
+						Type:    "PodScheduled",
+						Status:  "False",
+						Reason:  "Unschedulable",
+						Message: "0/3 nodes are available",
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-unschedulable",
+			expectedReason:   "Unschedulable",
+		},
+		{
+			name: "Evicted pod",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "evicted-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase:   "Failed",
+					Reason:  "Evicted",
+					Message: "The node was low on resource: memory.",
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-evicted",
+			expectedReason:   "Evicted",
+		},
+		{
+			name: "Init container failure",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "init-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Init:Error",
+					InitContainerStatuses: []K8sContainerStatus{{
+						Name: "init",
+						State: K8sContainerState{
+							Terminated: &K8sContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							},
+						},
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-init-failure",
+		},
+		{
+			name: "High restart count",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "restart-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Running",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name:         "app",
+						Ready:        true,
+						RestartCount: 10,
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-high-restarts",
+			expectedReason:   "HighRestartCount",
+		},
+		{
+			name: "Pod running but container not ready",
+			pods: &K8sPodList{Items: []K8sPod{{
+				Metadata: K8sObjectMeta{Name: "notready-pod", Namespace: "ns"},
+				Status: K8sPodStatus{
+					Phase: "Running",
+					ContainerStatuses: []K8sContainerStatus{{
+						Name:  "app",
+						Ready: false,
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "pod-not-ready",
+			expectedReason:   "ContainerNotReady",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectPodFailures(tt.pods)
+			if len(findings) != tt.expectedCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+			if tt.expectedCount > 0 {
+				if findings[0].Detector != tt.expectedDetector {
+					t.Errorf("expected detector %q, got %q", tt.expectedDetector, findings[0].Detector)
+				}
+				if tt.expectedReason != "" && findings[0].Reason != tt.expectedReason {
+					t.Errorf("expected reason %q, got %q", tt.expectedReason, findings[0].Reason)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectNodeFailures(t *testing.T) {
+	tests := []struct {
+		name             string
+		nodes            *K8sNodeList
+		expectedCount    int
+		expectedDetector string
+		expectedReason   string
+	}{
+		{
+			name:          "nil nodes",
+			nodes:         nil,
+			expectedCount: 0,
+		},
+		{
+			name: "healthy node",
+			nodes: &K8sNodeList{Items: []K8sNode{{
+				Metadata: K8sObjectMeta{Name: "node1"},
+				Status: K8sNodeStatus{
+					Conditions: []K8sNodeCondition{
+						{Type: "Ready", Status: "True"},
+						{Type: "DiskPressure", Status: "False"},
+						{Type: "MemoryPressure", Status: "False"},
+						{Type: "PIDPressure", Status: "False"},
+					},
+				},
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "NotReady node",
+			nodes: &K8sNodeList{Items: []K8sNode{{
+				Metadata: K8sObjectMeta{Name: "node1"},
+				Status: K8sNodeStatus{
+					Conditions: []K8sNodeCondition{{
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "KubeletNotReady",
+						Message: "container runtime is down",
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "node-not-ready",
+			expectedReason:   "KubeletNotReady",
+		},
+		{
+			name: "MemoryPressure",
+			nodes: &K8sNodeList{Items: []K8sNode{{
+				Metadata: K8sObjectMeta{Name: "node1"},
+				Status: K8sNodeStatus{
+					Conditions: []K8sNodeCondition{{
+						Type:   "MemoryPressure",
+						Status: "True",
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "node-pressure",
+			expectedReason:   "MemoryPressure",
+		},
+		{
+			name: "DiskPressure",
+			nodes: &K8sNodeList{Items: []K8sNode{{
+				Metadata: K8sObjectMeta{Name: "node1"},
+				Status: K8sNodeStatus{
+					Conditions: []K8sNodeCondition{{
+						Type:   "DiskPressure",
+						Status: "True",
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "node-pressure",
+			expectedReason:   "DiskPressure",
+		},
+		{
+			name: "NetworkUnavailable",
+			nodes: &K8sNodeList{Items: []K8sNode{{
+				Metadata: K8sObjectMeta{Name: "node1"},
+				Status: K8sNodeStatus{
+					Conditions: []K8sNodeCondition{{
+						Type:    "NetworkUnavailable",
+						Status:  "True",
+						Reason:  "NoRouteCreated",
+						Message: "route not created",
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "node-network-unavailable",
+			expectedReason:   "NoRouteCreated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectNodeFailures(tt.nodes)
+			if len(findings) != tt.expectedCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+			if tt.expectedCount > 0 {
+				if findings[0].Detector != tt.expectedDetector {
+					t.Errorf("expected detector %q, got %q", tt.expectedDetector, findings[0].Detector)
+				}
+				if tt.expectedReason != "" && findings[0].Reason != tt.expectedReason {
+					t.Errorf("expected reason %q, got %q", tt.expectedReason, findings[0].Reason)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectEventFailures(t *testing.T) {
+	tests := []struct {
+		name             string
+		events           *K8sEventList
+		expectedCount    int
+		expectedSeverity string
+	}{
+		{
+			name:          "nil events",
+			events:        nil,
+			expectedCount: 0,
+		},
+		{
+			name: "Normal events ignored",
+			events: &K8sEventList{Items: []K8sEvent{{
+				Type:   "Normal",
+				Reason: "Pulled",
+				Count:  1,
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "Critical warning event",
+			events: &K8sEventList{Items: []K8sEvent{{
+				Type:           "Warning",
+				Reason:         "FailedScheduling",
+				Message:        "0/3 nodes are available",
+				Count:          5,
+				InvolvedObject: K8sObjectReference{Kind: "Pod", Name: "test", Namespace: "ns"},
+			}}},
+			expectedCount:    1,
+			expectedSeverity: "error",
+		},
+		{
+			name: "Non-critical warning event",
+			events: &K8sEventList{Items: []K8sEvent{{
+				Type:           "Warning",
+				Reason:         "SomeOtherReason",
+				Message:        "something happened",
+				Count:          1,
+				InvolvedObject: K8sObjectReference{Kind: "Pod", Name: "test", Namespace: "ns"},
+			}}},
+			expectedCount:    1,
+			expectedSeverity: "warning",
+		},
+		{
+			name: "Event with zero count treated as 1",
+			events: &K8sEventList{Items: []K8sEvent{{
+				Type:           "Warning",
+				Reason:         "BackOff",
+				Message:        "back-off restarting",
+				Count:          0,
+				InvolvedObject: K8sObjectReference{Kind: "Pod", Name: "test", Namespace: "ns"},
+			}}},
+			expectedCount:    1,
+			expectedSeverity: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectEventFailures(tt.events)
+			if len(findings) != tt.expectedCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+			if tt.expectedCount > 0 && tt.expectedSeverity != "" {
+				if findings[0].Severity != tt.expectedSeverity {
+					t.Errorf("expected severity %q, got %q", tt.expectedSeverity, findings[0].Severity)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectVMIFailures(t *testing.T) {
+	tests := []struct {
+		name             string
+		vmis             *K8sVMIList
+		expectedCount    int
+		expectedDetector string
+		expectedSeverity string
+	}{
+		{
+			name:          "nil vmis",
+			vmis:          nil,
+			expectedCount: 0,
+		},
+		{
+			name: "Running VMI",
+			vmis: &K8sVMIList{Items: []K8sVMI{{
+				Status: K8sVMIStatus{Phase: "Running"},
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "Succeeded VMI",
+			vmis: &K8sVMIList{Items: []K8sVMI{{
+				Status: K8sVMIStatus{Phase: "Succeeded"},
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "Failed VMI",
+			vmis: &K8sVMIList{Items: []K8sVMI{{
+				Metadata: K8sObjectMeta{Name: "vmi1", Namespace: "ns"},
+				Status:   K8sVMIStatus{Phase: "Failed"},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "vmi-not-running",
+			expectedSeverity: "error",
+		},
+		{
+			name: "Scheduling VMI",
+			vmis: &K8sVMIList{Items: []K8sVMI{{
+				Metadata: K8sObjectMeta{Name: "vmi1", Namespace: "ns"},
+				Status:   K8sVMIStatus{Phase: "Scheduling"},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "vmi-not-running",
+			expectedSeverity: "warning",
+		},
+		{
+			name: "Failed migration",
+			vmis: &K8sVMIList{Items: []K8sVMI{{
+				Metadata: K8sObjectMeta{Name: "vmi1", Namespace: "ns"},
+				Status: K8sVMIStatus{
+					Phase: "Running",
+					MigrationState: &K8sMigrationState{
+						Failed:         true,
+						SourceNodeName: "node1",
+						TargetNodeName: "node2",
+					},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "vmi-migration-failed",
+			expectedSeverity: "error",
+		},
+		{
+			name: "VMI not ready condition",
+			vmis: &K8sVMIList{Items: []K8sVMI{{
+				Metadata: K8sObjectMeta{Name: "vmi1", Namespace: "ns"},
+				Status: K8sVMIStatus{
+					Phase: "Running",
+					Conditions: []K8sVMICondition{{
+						Type:    "Ready",
+						Status:  "False",
+						Reason:  "GuestNotRunning",
+						Message: "guest agent not running",
+					}},
+				},
+			}}},
+			expectedCount:    1,
+			expectedDetector: "vmi-not-ready",
+			expectedSeverity: "warning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectVMIFailures(tt.vmis)
+			if len(findings) != tt.expectedCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+			if tt.expectedCount > 0 {
+				if findings[0].Detector != tt.expectedDetector {
+					t.Errorf("expected detector %q, got %q", tt.expectedDetector, findings[0].Detector)
+				}
+				if findings[0].Severity != tt.expectedSeverity {
+					t.Errorf("expected severity %q, got %q", tt.expectedSeverity, findings[0].Severity)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectVMIMFailures(t *testing.T) {
+	tests := []struct {
+		name          string
+		vmims         *K8sVMIMList
+		expectedCount int
+	}{
+		{
+			name:          "nil vmims",
+			vmims:         nil,
+			expectedCount: 0,
+		},
+		{
+			name: "Succeeded VMIM",
+			vmims: &K8sVMIMList{Items: []K8sVMIM{{
+				Status: K8sVMIMStatus{Phase: "Succeeded"},
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "Failed VMIM",
+			vmims: &K8sVMIMList{Items: []K8sVMIM{{
+				Metadata: K8sObjectMeta{Name: "mig1", Namespace: "ns"},
+				Status:   K8sVMIMStatus{Phase: "Failed"},
+			}}},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectVMIMFailures(tt.vmims)
+			if len(findings) != tt.expectedCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+			if tt.expectedCount > 0 {
+				if findings[0].Detector != "vmim-failed" {
+					t.Errorf("expected detector %q, got %q", "vmim-failed", findings[0].Detector)
+				}
+			}
+		})
+	}
+}

--- a/pkg/ci-failures/k8s_detectors_test.go
+++ b/pkg/ci-failures/k8s_detectors_test.go
@@ -508,6 +508,114 @@ func TestDetectVMIFailures(t *testing.T) {
 	}
 }
 
+func TestDetectEtcdIssues(t *testing.T) {
+	tests := []struct {
+		name             string
+		profile          *EtcdStorageProfile
+		expectedCount    int
+		expectedDetector string
+		expectedSeverity string
+	}{
+		{
+			name:          "nil profile",
+			profile:       nil,
+			expectedCount: 0,
+		},
+		{
+			name: "healthy profile",
+			profile: &EtcdStorageProfile{
+				TotalSpecs:      10,
+				FinalTmpfsTotal: 1024 * 1024 * 1024,
+				PeakTmpfsUsed:   100 * 1024 * 1024,
+				FinalWALSize:    50 * 1024 * 1024,
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "tmpfs exhaustion over 90%",
+			profile: &EtcdStorageProfile{
+				TotalSpecs:      10,
+				FinalTmpfsTotal: 512 * 1024 * 1024,
+				PeakTmpfsUsed:   480 * 1024 * 1024, // ~93.75%
+				FinalWALSize:    50 * 1024 * 1024,
+			},
+			expectedCount:    1,
+			expectedDetector: "etcd-tmpfs-exhaustion",
+			expectedSeverity: "error",
+		},
+		{
+			name: "tmpfs pressure between 75% and 90%",
+			profile: &EtcdStorageProfile{
+				TotalSpecs:      10,
+				FinalTmpfsTotal: 512 * 1024 * 1024,
+				PeakTmpfsUsed:   420 * 1024 * 1024, // ~82%
+				FinalWALSize:    50 * 1024 * 1024,
+			},
+			expectedCount:    1,
+			expectedDetector: "etcd-tmpfs-pressure",
+			expectedSeverity: "warning",
+		},
+		{
+			name: "large WAL over 50% of tmpfs",
+			profile: &EtcdStorageProfile{
+				TotalSpecs:      10,
+				FinalTmpfsTotal: 512 * 1024 * 1024,
+				PeakTmpfsUsed:   100 * 1024 * 1024,
+				FinalWALSize:    300 * 1024 * 1024, // ~58.6%
+			},
+			expectedCount:    1,
+			expectedDetector: "etcd-large-wal",
+			expectedSeverity: "warning",
+		},
+		{
+			name: "DB growth across specs",
+			profile: &EtcdStorageProfile{
+				TotalSpecs:      3,
+				FinalTmpfsTotal: 1024 * 1024 * 1024,
+				PeakTmpfsUsed:   100 * 1024 * 1024,
+				FinalWALSize:    50 * 1024 * 1024,
+				Records: []EtcdStorageSpecRecord{
+					{SpecName: "spec1", DeltaDBSize: 1000},
+					{SpecName: "spec2", DeltaDBSize: -500},
+					{SpecName: "spec3", DeltaDBSize: 2000},
+				},
+			},
+			expectedCount:    1,
+			expectedDetector: "etcd-db-growth",
+			expectedSeverity: "info",
+		},
+		{
+			name: "zero tmpfs total avoids division by zero",
+			profile: &EtcdStorageProfile{
+				TotalSpecs:      1,
+				FinalTmpfsTotal: 0,
+				PeakTmpfsUsed:   100,
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := detectEtcdIssues(tt.profile)
+			if len(findings) != tt.expectedCount {
+				t.Fatalf("expected %d findings, got %d: %+v", tt.expectedCount, len(findings), findings)
+			}
+			if tt.expectedCount > 0 {
+				if findings[0].Detector != tt.expectedDetector {
+					t.Errorf("expected detector %q, got %q", tt.expectedDetector, findings[0].Detector)
+				}
+				if findings[0].Severity != tt.expectedSeverity {
+					t.Errorf("expected severity %q, got %q", tt.expectedSeverity, findings[0].Severity)
+				}
+				if findings[0].Kind != "EtcdProfile" {
+					t.Errorf("expected kind %q, got %q", "EtcdProfile", findings[0].Kind)
+				}
+			}
+		})
+	}
+}
+
 func TestDetectVMIMFailures(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/ci-failures/k8s_types.go
+++ b/pkg/ci-failures/k8s_types.go
@@ -197,14 +197,55 @@ type K8sFinding struct {
 
 // K8sAnalysisResult is the top-level output for analyze-k8s.
 type K8sAnalysisResult struct {
-	ProwJobURL string        `yaml:"prow_job_url"`
-	JobName    string        `yaml:"job_name"`
-	BuildID    int           `yaml:"build_id"`
-	Started    time.Time     `yaml:"started"`
-	Finished   time.Time     `yaml:"finished"`
-	Snapshots  []K8sSnapshot `yaml:"snapshots"`
-	Findings   []*K8sFinding `yaml:"findings"`
-	Summary    K8sSummary    `yaml:"summary"`
+	ProwJobURL  string               `yaml:"prow_job_url"`
+	JobName     string               `yaml:"job_name"`
+	BuildID     int                  `yaml:"build_id"`
+	Started     time.Time            `yaml:"started"`
+	Finished    time.Time            `yaml:"finished"`
+	Snapshots   []K8sSnapshot        `yaml:"snapshots"`
+	Findings    []*K8sFinding        `yaml:"findings"`
+	Summary     K8sSummary           `yaml:"summary"`
+	EtcdProfile *EtcdStorageProfile  `yaml:"etcd_profile,omitempty"`
+}
+
+// EtcdStorageProfile is the top-level structure of etcd-storage-profile.json
+// produced by the etcd profiler in kubevirt test runs.
+type EtcdStorageProfile struct {
+	CollectedAt     string                  `json:"collectedAt"     yaml:"collected_at"`
+	TotalSpecs      int                     `json:"totalSpecs"      yaml:"total_specs"`
+	FinalDBSize     int64                   `json:"finalDBSizeBytes"     yaml:"final_db_size_bytes"`
+	FinalTmpfsUsed  int64                   `json:"finalTmpfsUsedBytes"  yaml:"final_tmpfs_used_bytes"`
+	FinalTmpfsTotal int64                   `json:"finalTmpfsTotalBytes" yaml:"final_tmpfs_total_bytes"`
+	FinalWALSize    int64                   `json:"finalWALSizeBytes"    yaml:"final_wal_size_bytes"`
+	FinalSnapSize   int64                   `json:"finalSnapSizeBytes"   yaml:"final_snap_size_bytes"`
+	PeakTmpfsUsed   int64                   `json:"peakTmpfsUsedBytes"   yaml:"peak_tmpfs_used_bytes"`
+	PeakDBSize      int64                   `json:"peakDBSizeBytes"      yaml:"peak_db_size_bytes"`
+	Records         []EtcdStorageSpecRecord `json:"records"              yaml:"records,omitempty"`
+}
+
+// EtcdStorageSnapshot captures a point-in-time etcd state measurement.
+type EtcdStorageSnapshot struct {
+	DBSizeBytes      int64  `json:"dbSizeBytes"      yaml:"db_size_bytes"`
+	DBSizeInUseBytes int64  `json:"dbSizeInUseBytes"  yaml:"db_size_in_use_bytes"`
+	Revision         int64  `json:"revision"          yaml:"revision"`
+	TmpfsUsedBytes   int64  `json:"tmpfsUsedBytes"    yaml:"tmpfs_used_bytes"`
+	TmpfsTotalBytes  int64  `json:"tmpfsTotalBytes"   yaml:"tmpfs_total_bytes"`
+	TmpfsAvailBytes  int64  `json:"tmpfsAvailBytes"   yaml:"tmpfs_avail_bytes"`
+	WALSizeBytes     int64  `json:"walSizeBytes"      yaml:"wal_size_bytes"`
+	SnapSizeBytes    int64  `json:"snapSizeBytes"     yaml:"snap_size_bytes"`
+	Error            string `json:"error,omitempty"   yaml:"error,omitempty"`
+}
+
+// EtcdStorageSpecRecord captures etcd state before and after a single test spec.
+type EtcdStorageSpecRecord struct {
+	SpecName        string              `json:"specName"           yaml:"spec_name"`
+	Before          EtcdStorageSnapshot `json:"before"             yaml:"before"`
+	After           EtcdStorageSnapshot `json:"after"              yaml:"after"`
+	DeltaDBSize     int64               `json:"deltaDBSizeBytes"   yaml:"delta_db_size_bytes"`
+	DeltaTmpfsUsed  int64               `json:"deltaTmpfsUsedBytes" yaml:"delta_tmpfs_used_bytes"`
+	DeltaRevision   int64               `json:"deltaRevision"      yaml:"delta_revision"`
+	Passed          bool                `json:"passed"             yaml:"passed"`
+	DurationSeconds float64             `json:"durationSeconds"    yaml:"duration_seconds"`
 }
 
 // K8sSummary provides aggregate counts by kind, severity, and detector.

--- a/pkg/ci-failures/k8s_types.go
+++ b/pkg/ci-failures/k8s_types.go
@@ -1,0 +1,216 @@
+package cifailures
+
+import (
+	"fmt"
+	"time"
+)
+
+// K8sObjectMeta captures the metadata fields we inspect.
+type K8sObjectMeta struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
+}
+
+// K8sPodList is a lightweight representation of a core/v1 PodList.
+type K8sPodList struct {
+	Items []K8sPod `json:"items"`
+}
+
+type K8sPod struct {
+	Metadata K8sObjectMeta `json:"metadata"`
+	Spec     K8sPodSpec    `json:"spec"`
+	Status   K8sPodStatus  `json:"status"`
+}
+
+type K8sPodSpec struct {
+	NodeName       string         `json:"nodeName,omitempty"`
+	InitContainers []K8sContainer `json:"initContainers,omitempty"`
+	Containers     []K8sContainer `json:"containers,omitempty"`
+}
+
+type K8sContainer struct {
+	Name  string `json:"name"`
+	Image string `json:"image"`
+}
+
+type K8sPodStatus struct {
+	Phase                 string               `json:"phase"`
+	Reason                string               `json:"reason,omitempty"`
+	Message               string               `json:"message,omitempty"`
+	Conditions            []K8sPodCondition    `json:"conditions,omitempty"`
+	ContainerStatuses     []K8sContainerStatus `json:"containerStatuses,omitempty"`
+	InitContainerStatuses []K8sContainerStatus `json:"initContainerStatuses,omitempty"`
+}
+
+type K8sPodCondition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type K8sContainerStatus struct {
+	Name                 string            `json:"name"`
+	Ready                bool              `json:"ready"`
+	RestartCount         int               `json:"restartCount"`
+	State                K8sContainerState `json:"state,omitzero"`
+	LastTerminationState K8sContainerState `json:"lastTerminationState,omitzero"`
+}
+
+type K8sContainerState struct {
+	Waiting    *K8sContainerStateWaiting    `json:"waiting,omitempty"`
+	Running    *K8sContainerStateRunning    `json:"running,omitempty"`
+	Terminated *K8sContainerStateTerminated `json:"terminated,omitempty"`
+}
+
+type K8sContainerStateWaiting struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message,omitempty"`
+}
+
+type K8sContainerStateRunning struct {
+	StartedAt string `json:"startedAt,omitempty"`
+}
+
+type K8sContainerStateTerminated struct {
+	ExitCode   int    `json:"exitCode"`
+	Reason     string `json:"reason,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Signal     int    `json:"signal,omitempty"`
+	StartedAt  string `json:"startedAt,omitempty"`
+	FinishedAt string `json:"finishedAt,omitempty"`
+}
+
+// K8sNodeList is a lightweight representation of a core/v1 NodeList.
+type K8sNodeList struct {
+	Items []K8sNode `json:"items"`
+}
+
+type K8sNode struct {
+	Metadata K8sObjectMeta `json:"metadata"`
+	Status   K8sNodeStatus `json:"status"`
+}
+
+type K8sNodeStatus struct {
+	Conditions []K8sNodeCondition `json:"conditions,omitempty"`
+}
+
+type K8sNodeCondition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// K8sEventList is a lightweight representation of a core/v1 EventList.
+type K8sEventList struct {
+	Items []K8sEvent `json:"items"`
+}
+
+type K8sEvent struct {
+	Metadata       K8sObjectMeta      `json:"metadata"`
+	InvolvedObject K8sObjectReference `json:"involvedObject"`
+	Reason         string             `json:"reason"`
+	Message        string             `json:"message"`
+	Type           string             `json:"type"`
+	Count          int                `json:"count"`
+	LastTimestamp  string             `json:"lastTimestamp,omitempty"`
+	FirstTimestamp string             `json:"firstTimestamp,omitempty"`
+}
+
+type K8sObjectReference struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// K8sVMIList is a lightweight representation of a KubeVirt VirtualMachineInstanceList.
+type K8sVMIList struct {
+	Items []K8sVMI `json:"items"`
+}
+
+type K8sVMI struct {
+	Metadata K8sObjectMeta `json:"metadata"`
+	Status   K8sVMIStatus  `json:"status"`
+}
+
+type K8sVMIStatus struct {
+	Phase          string             `json:"phase"`
+	Reason         string             `json:"reason,omitempty"`
+	Conditions     []K8sVMICondition  `json:"conditions,omitempty"`
+	MigrationState *K8sMigrationState `json:"migrationState,omitempty"`
+}
+
+type K8sVMICondition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type K8sMigrationState struct {
+	Completed      bool   `json:"completed"`
+	Failed         bool   `json:"failed"`
+	TargetNodeName string `json:"targetNode,omitempty"`
+	SourceNodeName string `json:"sourceNode,omitempty"`
+}
+
+// K8sVMIMList is a lightweight representation of a KubeVirt VirtualMachineInstanceMigrationList.
+type K8sVMIMList struct {
+	Items []K8sVMIM `json:"items"`
+}
+
+type K8sVMIM struct {
+	Metadata K8sObjectMeta `json:"metadata"`
+	Status   K8sVMIMStatus `json:"status"`
+}
+
+type K8sVMIMStatus struct {
+	Phase string `json:"phase"`
+}
+
+// K8sSnapshot identifies a cluster state capture point: a parallel process
+// number and a failure count within that process.
+type K8sSnapshot struct {
+	Process      string `yaml:"process"`
+	FailureCount int    `yaml:"failure_count"`
+}
+
+func (s K8sSnapshot) String() string {
+	return fmt.Sprintf("process=%s/failure=%d", s.Process, s.FailureCount)
+}
+
+// K8sFinding represents a single detected problem in a k8s object.
+type K8sFinding struct {
+	Detector  string      `yaml:"detector"`
+	Severity  string      `yaml:"severity"`
+	Kind      string      `yaml:"kind"`
+	Namespace string      `yaml:"namespace,omitempty"`
+	Name      string      `yaml:"name"`
+	Reason    string      `yaml:"reason"`
+	Message   string      `yaml:"message"`
+	Detail    string      `yaml:"detail,omitempty"`
+	Snapshot  K8sSnapshot `yaml:"snapshot"`
+}
+
+// K8sAnalysisResult is the top-level output for analyze-k8s.
+type K8sAnalysisResult struct {
+	ProwJobURL string        `yaml:"prow_job_url"`
+	JobName    string        `yaml:"job_name"`
+	BuildID    int           `yaml:"build_id"`
+	Started    time.Time     `yaml:"started"`
+	Finished   time.Time     `yaml:"finished"`
+	Snapshots  []K8sSnapshot `yaml:"snapshots"`
+	Findings   []*K8sFinding `yaml:"findings"`
+	Summary    K8sSummary    `yaml:"summary"`
+}
+
+// K8sSummary provides aggregate counts by kind, severity, and detector.
+type K8sSummary struct {
+	TotalFindings int            `yaml:"total_findings"`
+	ByKind        map[string]int `yaml:"by_kind"`
+	BySeverity    map[string]int `yaml:"by_severity"`
+	ByDetector    map[string]int `yaml:"by_detector"`
+}


### PR DESCRIPTION
## Summary

- Add `analyze-k8s` CLI subcommand that downloads k8s-reporter artifacts (pods, nodes, events, VMIs, VMIMs) from GCS, parses them, and runs failure detectors to surface cluster-level issues
- Integrate k8s analysis into `analyze-build` and `analyze-pr` so cluster state findings are produced alongside build log analysis automatically
- Add failure detectors for: CrashLoopBackOff, OOMKilled, ImagePullBackOff, unschedulable pods, evicted pods, NotReady nodes, resource pressure, warning events, failed VMI migrations, and more
- Support multi-snapshot discovery across parallel Ginkgo processes and multiple failure counts per process

## Test plan

- [x] `go build ./cmd/ci-failures/` compiles
- [x] `go test ./pkg/ci-failures/...` passes (25 detector tests + 10 orchestration/parsing tests)
- [x] `go vet ./...` clean
- [x] Manual test with real Prow URLs producing expected YAML output with findings from all snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)