### PR TITLE
feat: add container log analysis to analyze-build skill

### DIFF
--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -3,17 +3,18 @@ name: analyze-build
 description: >
     Analyze the root cause inside a failed prowjob.
     Use when user mentions to analyze a prowjob failure or adds a prowjob url
-allowed-tools: [Read, Glob, Bash(go run:*)]
+allowed-tools: [Read, Glob, Bash(go run:*), Bash(grep:*)]
 ---
 
 ## Overview
 
 This skill helps the user to find the root cause and mitigations for failing prowjobs.
 
-It combines three analyses:
+It combines four analyses:
 1. **Build log analysis** — extracts error snippets from the build log and categorizes them
 2. **Kubernetes cluster state analysis** — downloads k8s-reporter artifacts (pods, nodes, events, VMIs) and detects infrastructure-level failures like CrashLoopBackOff, OOMKilled, NotReady nodes, failed migrations, and warning events
 3. **Etcd storage profiling** — if the job was run with `KUBEVIRT_PROFILE_ETCD=true`, downloads `etcd-storage-profile.json` from `artifacts/etcd-profiler/` and detects tmpfs exhaustion, tmpfs pressure, large WAL files, and DB growth trends
+4. **Container log analysis** — downloads virt-controller, virt-handler, virt-api, and virt-operator container logs from k8s-reporter suite artifacts for interactive grep
 
 ## Analysis data generation
 
@@ -42,5 +43,14 @@ After data generation:
    - `findings`: list of detected issues, each with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
    - `summary`: aggregate counts by kind, severity, and detector
    - `etcd_profile` (optional): full etcd storage profile with `peak_tmpfs_used_bytes`, `final_tmpfs_total_bytes`, `final_wal_size_bytes`, and per-spec `records` showing DB size deltas and tmpfs usage. Etcd-related findings use kind `EtcdProfile` and detectors `etcd-tmpfs-exhaustion`, `etcd-tmpfs-pressure`, `etcd-large-wal`, `etcd-db-growth`
-4. Correlate all analyses: k8s findings (e.g. CrashLoopBackOff on a component pod) often explain build log errors (e.g. test timeouts); etcd findings (e.g. tmpfs exhaustion) can explain node-level or apiserver issues
-5. Deduce the root cause and possible mitigations from the combined data
+4. Read the container log files list from `container_log_files` in the k8s analysis YAML. Each entry has:
+   - `pod_name`, `container_name`, `namespace`: identify the component
+   - `cached_path`: local file path to grep
+   - `size_bytes`: file size
+5. **Cross-reference failing VMI/VM names against container logs**: extract VMI/VM names from build log errors (e.g. `testvmi-xxxxx`) and k8s findings (e.g. VMIs stuck in Scheduling), then use `grep` on the cached virt-controller and virt-handler logs to find why those VMIs failed. Common patterns to look for:
+   - Schema validation errors (e.g. `admission webhook` or `validation failed`)
+   - Sync failures (e.g. `syncError` or `failed to sync`)
+   - Device/resource issues (e.g. `device not found`, `resource not available`)
+   - Example: `grep -i "testvmi-xxxxx" <cached_path>` to find all log lines related to a specific VMI
+6. Correlate all analyses: k8s findings (e.g. CrashLoopBackOff on a component pod) often explain build log errors (e.g. test timeouts); etcd findings (e.g. tmpfs exhaustion) can explain node-level or apiserver issues; container log errors (e.g. schema validation failures in virt-controller) reveal the actual rejection reason when VMIs are stuck in non-Running phases
+7. Deduce the root cause and possible mitigations from the combined data

--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -3,7 +3,7 @@ name: analyze-pr-builds
 description: >
     Analyze all failed builds for a GitHub pull request.
     Use when user provides a GitHub PR URL and wants to understand why builds are failing.
-allowed-tools: [Read, Glob, Bash(go run:*)]
+allowed-tools: [Read, Glob, Bash(go run:*), Bash(grep:*)]
 ---
 
 ## Overview
@@ -47,9 +47,11 @@ After data generation:
    - `findings`: list of detected issues with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
    - `summary`: aggregate counts by kind, severity, and detector
    - `etcd_profile` (optional): full etcd storage profile with peak/final tmpfs and WAL metrics, plus per-spec records. Etcd-related findings use kind `EtcdProfile` and detectors `etcd-tmpfs-exhaustion`, `etcd-tmpfs-pressure`, `etcd-large-wal`, `etcd-db-growth`
-4. For each failure, examine build log errors AND k8s findings to determine the root cause
-5. Correlate k8s findings with build log errors — e.g. CrashLoopBackOff on a component pod often explains test timeouts; etcd tmpfs exhaustion can explain apiserver or node-level failures
-6. Group failures with the same root cause together
+   - `container_log_files` (optional): list of cached kubevirt component container logs (virt-controller, virt-handler, virt-api, virt-operator) with `pod_name`, `container_name`, `namespace`, `cached_path`, and `size_bytes`
+4. **Cross-reference failing VMI/VM names against container logs**: extract VMI/VM names from build log errors and k8s findings, then use `grep` on the cached virt-controller and virt-handler logs to find the actual rejection reason. Example: `grep -i "testvmi-xxxxx" <cached_path>`
+5. For each failure, examine build log errors, k8s findings, AND container log matches to determine the root cause
+6. Correlate findings across all sources — e.g. CrashLoopBackOff on a component pod often explains test timeouts; etcd tmpfs exhaustion can explain apiserver failures; virt-controller log errors (schema validation, sync failures) reveal why VMIs are stuck in non-Running phases
+7. Group failures with the same root cause together
 
 ## Output
 

--- a/pkg/ci-failures/k8s_analyze.go
+++ b/pkg/ci-failures/k8s_analyze.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -99,16 +100,19 @@ func AnalyzeK8s(prowJobURL string) (*K8sAnalysisResult, error) {
 		allFindings = append(allFindings, etcdFindings...)
 	}
 
+	containerLogFiles := fetchContainerLogs(gcsBaseURL, cacheDir)
+
 	result := &K8sAnalysisResult{
-		ProwJobURL:  prowJobURL,
-		JobName:     jobName,
-		BuildID:     buildID,
-		Started:     started,
-		Finished:    finished,
-		Snapshots:   snapshotList,
-		Findings:    allFindings,
-		Summary:     buildSummary(allFindings),
-		EtcdProfile: etcdProfile,
+		ProwJobURL:        prowJobURL,
+		JobName:           jobName,
+		BuildID:           buildID,
+		Started:           started,
+		Finished:          finished,
+		Snapshots:         snapshotList,
+		Findings:          allFindings,
+		Summary:           buildSummary(allFindings),
+		EtcdProfile:       etcdProfile,
+		ContainerLogFiles: containerLogFiles,
 	}
 
 	return result, nil
@@ -312,6 +316,222 @@ func fetchEtcdProfile(gcsBaseURL, cacheDir string) *EtcdStorageProfile {
 	log.Infof("loaded etcd profile: %d specs, peak tmpfs %d/%d bytes",
 		profile.TotalSpecs, profile.PeakTmpfsUsed, profile.FinalTmpfsTotal)
 	return &profile
+}
+
+var containerLogComponents = []string{
+	"virt-controller",
+	"virt-handler",
+	"virt-api",
+	"virt-operator",
+}
+
+func fetchContainerLogs(gcsBaseURL, cacheDir string) []ContainerLogFile {
+	k8sReporterBase := gcsBaseURL + "/artifacts/k8s-reporter"
+
+	// Container logs are in suite snapshots: {n}_{namespace}_{podName}-{containerName}.log
+	// Try suite first, then flat layout.
+	bases := []string{
+		k8sReporterBase + "/suite",
+		k8sReporterBase,
+	}
+
+	for _, base := range bases {
+		files := discoverContainerLogFiles(base)
+		if len(files) == 0 {
+			continue
+		}
+
+		logCacheDir := filepath.Join(cacheDir, "container-logs")
+		if err := os.MkdirAll(logCacheDir, 0755); err != nil {
+			log.WithError(err).Warn("failed to create container-logs cache dir")
+			return nil
+		}
+
+		var result []ContainerLogFile
+		for _, f := range files {
+			cached, size, err := downloadContainerLog(f.url, logCacheDir, f.fileName)
+			if err != nil {
+				log.WithError(err).Warnf("failed to download container log %s", f.fileName)
+				continue
+			}
+			result = append(result, ContainerLogFile{
+				PodName:       f.podName,
+				ContainerName: f.containerName,
+				Namespace:     f.namespace,
+				CachedPath:    cached,
+				SizeBytes:     size,
+			})
+			log.Infof("cached container log %s (%d bytes)", f.fileName, size)
+		}
+		return result
+	}
+
+	log.Info("no container log files found for kubevirt components")
+	return nil
+}
+
+type containerLogMeta struct {
+	fileName      string
+	namespace     string
+	podName       string
+	containerName string
+	url           string
+}
+
+// gcsListResponse is the JSON response from the GCS Storage JSON API list objects endpoint.
+type gcsListResponse struct {
+	Items []struct {
+		Name string `json:"name"`
+		Size string `json:"size"`
+	} `json:"items"`
+	NextPageToken string `json:"nextPageToken"`
+}
+
+// gcsBaseToListURL converts a GCS storage URL to the corresponding JSON API listing URL.
+// Returns the listing URL and the download base URL, or empty strings if parsing fails.
+func gcsBaseToListURL(gcsBasePath string) (listURL, downloadBase string) {
+	const storagePrefix = "https://storage.googleapis.com/"
+	if !strings.HasPrefix(gcsBasePath, storagePrefix) {
+		return "", ""
+	}
+
+	remainder := strings.TrimPrefix(gcsBasePath, storagePrefix)
+	slashIdx := strings.Index(remainder, "/")
+	if slashIdx < 0 {
+		return "", ""
+	}
+	bucket := remainder[:slashIdx]
+	prefix := remainder[slashIdx+1:]
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	return fmt.Sprintf("%sstorage/v1/b/%s/o?prefix=%s&maxResults=500", storagePrefix, bucket, prefix),
+		storagePrefix + bucket + "/"
+}
+
+func discoverContainerLogFiles(gcsBasePath string) []containerLogMeta {
+	listURL, downloadBase := gcsBaseToListURL(gcsBasePath)
+	if listURL == "" {
+		return nil
+	}
+	return listAndFilterContainerLogs(listURL, downloadBase)
+}
+
+func listAndFilterContainerLogs(listURL, downloadBase string) []containerLogMeta {
+	resp, err := http.Get(listURL)
+	if err != nil {
+		log.WithError(err).Warn("failed to list GCS objects for container logs")
+		return nil
+	}
+	defer closeAndLogErr(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		log.Warnf("GCS listing returned status %d", resp.StatusCode)
+		return nil
+	}
+
+	var listing gcsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		log.WithError(err).Warn("failed to decode GCS listing response")
+		return nil
+	}
+
+	var result []containerLogMeta
+	for _, item := range listing.Items {
+		fileName := filepath.Base(item.Name)
+		meta, ok := parseContainerLogFileName(fileName)
+		if !ok {
+			continue
+		}
+		if !isKubevirtComponent(meta.containerName) {
+			continue
+		}
+		meta.url = downloadBase + item.Name
+		result = append(result, meta)
+	}
+
+	return result
+}
+
+// parseContainerLogFileName parses filenames like "0_kubevirt_virt-controller-65cc5dc497-75jjr-virt-controller.log"
+// into namespace, pod name, and container name components.
+func parseContainerLogFileName(fileName string) (containerLogMeta, bool) {
+	if !strings.HasSuffix(fileName, ".log") {
+		return containerLogMeta{}, false
+	}
+
+	name := strings.TrimSuffix(fileName, ".log")
+
+	// Format: {n}_{namespace}_{podName}-{containerName}
+	// First segment before _ is the failure count number
+	firstUnderscore := strings.Index(name, "_")
+	if firstUnderscore < 0 {
+		return containerLogMeta{}, false
+	}
+
+	rest := name[firstUnderscore+1:]
+
+	// Second _ separates namespace from podName-containerName
+	secondUnderscore := strings.Index(rest, "_")
+	if secondUnderscore < 0 {
+		return containerLogMeta{}, false
+	}
+
+	namespace := rest[:secondUnderscore]
+	podContainer := rest[secondUnderscore+1:]
+
+	// The container name is the last hyphen-separated segment that matches a known
+	// component name. Since pod names can contain hyphens (e.g., "virt-controller-65cc5dc497-75jjr"),
+	// we find the container name by checking known suffixes.
+	for _, component := range containerLogComponents {
+		suffix := "-" + component
+		if strings.HasSuffix(podContainer, suffix) {
+			podName := podContainer[:len(podContainer)-len(suffix)]
+			return containerLogMeta{
+				fileName:      fileName,
+				namespace:     namespace,
+				podName:       podName,
+				containerName: component,
+			}, true
+		}
+	}
+
+	// Also match files where the pod name prefix equals the container name
+	// (e.g., "virt-handler" container in "virt-handler-n64dk" pod has suffix "-virt-handler")
+	// Already covered above. For "_previous" logs, skip them.
+	if strings.HasSuffix(podContainer, "_previous") {
+		return containerLogMeta{}, false
+	}
+
+	return containerLogMeta{}, false
+}
+
+func isKubevirtComponent(containerName string) bool {
+	return slices.Contains(containerLogComponents, containerName)
+}
+
+func downloadContainerLog(gcsURL, cacheDir, fileName string) (string, int64, error) {
+	cachePath := filepath.Join(cacheDir, fileName)
+
+	info, err := os.Stat(cachePath)
+	if err == nil {
+		return cachePath, info.Size(), nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", 0, err
+	}
+
+	raw, err := retrieveFileContentFromGCS(gcsURL)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if writeErr := os.WriteFile(cachePath, raw, 0644); writeErr != nil {
+		return "", 0, fmt.Errorf("failed to write cached log: %w", writeErr)
+	}
+
+	return cachePath, int64(len(raw)), nil
 }
 
 func buildSummary(findings []*K8sFinding) K8sSummary {

--- a/pkg/ci-failures/k8s_analyze.go
+++ b/pkg/ci-failures/k8s_analyze.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -406,7 +408,11 @@ func gcsBaseToListURL(gcsBasePath string) (listURL, downloadBase string) {
 		prefix += "/"
 	}
 
-	return fmt.Sprintf("%sstorage/v1/b/%s/o?prefix=%s&maxResults=500", storagePrefix, bucket, prefix),
+	v := url.Values{}
+	v.Set("prefix", prefix)
+	v.Set("maxResults", "500")
+
+	return fmt.Sprintf("%sstorage/v1/b/%s/o?%s", storagePrefix, bucket, v.Encode()),
 		storagePrefix + bucket + "/"
 }
 
@@ -419,36 +425,47 @@ func discoverContainerLogFiles(gcsBasePath string) []containerLogMeta {
 }
 
 func listAndFilterContainerLogs(listURL, downloadBase string) []containerLogMeta {
-	resp, err := http.Get(listURL)
-	if err != nil {
-		log.WithError(err).Warn("failed to list GCS objects for container logs")
-		return nil
-	}
-	defer closeAndLogErr(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		log.Warnf("GCS listing returned status %d", resp.StatusCode)
-		return nil
-	}
-
-	var listing gcsListResponse
-	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
-		log.WithError(err).Warn("failed to decode GCS listing response")
-		return nil
-	}
-
 	var result []containerLogMeta
-	for _, item := range listing.Items {
-		fileName := filepath.Base(item.Name)
-		meta, ok := parseContainerLogFileName(fileName)
-		if !ok {
-			continue
+	pageURL := listURL
+
+	for pageURL != "" {
+		resp, err := http.Get(pageURL)
+		if err != nil {
+			log.WithError(err).Warn("failed to list GCS objects for container logs")
+			return nil
 		}
-		if !isKubevirtComponent(meta.containerName) {
-			continue
+
+		if resp.StatusCode != http.StatusOK {
+			closeAndLogErr(resp.Body)
+			log.Warnf("GCS listing returned status %d", resp.StatusCode)
+			return nil
 		}
-		meta.url = downloadBase + item.Name
-		result = append(result, meta)
+
+		var listing gcsListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+			closeAndLogErr(resp.Body)
+			log.WithError(err).Warn("failed to decode GCS listing response")
+			return nil
+		}
+		closeAndLogErr(resp.Body)
+
+		for _, item := range listing.Items {
+			fileName := filepath.Base(item.Name)
+			meta, ok := parseContainerLogFileName(fileName)
+			if !ok {
+				continue
+			}
+			if !isKubevirtComponent(meta.containerName) {
+				continue
+			}
+			meta.url = downloadBase + item.Name
+			result = append(result, meta)
+		}
+
+		if listing.NextPageToken == "" {
+			break
+		}
+		pageURL = listURL + "&pageToken=" + url.QueryEscape(listing.NextPageToken)
 	}
 
 	return result
@@ -522,16 +539,28 @@ func downloadContainerLog(gcsURL, cacheDir, fileName string) (string, int64, err
 		return "", 0, err
 	}
 
-	raw, err := retrieveFileContentFromGCS(gcsURL)
+	resp, err := http.Get(gcsURL)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", 0, fmt.Errorf("failed to download log from GCS: status %d", resp.StatusCode)
+	}
+
+	out, err := os.Create(cachePath)
+	if err != nil {
+		return "", 0, err
+	}
+	defer out.Close()
+
+	size, err := io.Copy(out, resp.Body)
 	if err != nil {
 		return "", 0, err
 	}
 
-	if writeErr := os.WriteFile(cachePath, raw, 0644); writeErr != nil {
-		return "", 0, fmt.Errorf("failed to write cached log: %w", writeErr)
-	}
-
-	return cachePath, int64(len(raw)), nil
+	return cachePath, size, nil
 }
 
 func buildSummary(findings []*K8sFinding) K8sSummary {

--- a/pkg/ci-failures/k8s_analyze_test.go
+++ b/pkg/ci-failures/k8s_analyze_test.go
@@ -599,6 +599,52 @@ func TestListAndFilterContainerLogs(t *testing.T) {
 	}
 }
 
+func TestListAndFilterContainerLogsPagination(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/storage/v1/b/bucket/o", func(w http.ResponseWriter, r *http.Request) {
+		pageToken := r.URL.Query().Get("pageToken")
+		var resp gcsListResponse
+		switch pageToken {
+		case "":
+			resp = gcsListResponse{
+				Items: []struct {
+					Name string `json:"name"`
+					Size string `json:"size"`
+				}{
+					{Name: "suite/0_kubevirt_virt-controller-abc-virt-controller.log", Size: "1000"},
+				},
+				NextPageToken: "page2",
+			}
+		case "page2":
+			resp = gcsListResponse{
+				Items: []struct {
+					Name string `json:"name"`
+					Size string `json:"size"`
+				}{
+					{Name: "suite/0_kubevirt_virt-handler-xyz-virt-handler.log", Size: "2000"},
+				},
+			}
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	listURL := server.URL + "/storage/v1/b/bucket/o?prefix=suite%2F&maxResults=500"
+	files := listAndFilterContainerLogs(listURL, server.URL+"/")
+
+	if len(files) != 2 {
+		t.Fatalf("expected 2 container log files across pages, got %d", len(files))
+	}
+	if files[0].containerName != "virt-controller" {
+		t.Errorf("expected virt-controller first, got %q", files[0].containerName)
+	}
+	if files[1].containerName != "virt-handler" {
+		t.Errorf("expected virt-handler second, got %q", files[1].containerName)
+	}
+}
+
 func TestGcsBaseToListURL(t *testing.T) {
 	listURL, downloadBase := gcsBaseToListURL("https://storage.googleapis.com/kubevirt-prow/logs/job/123/artifacts/k8s-reporter/suite")
 	if listURL == "" {
@@ -606,6 +652,12 @@ func TestGcsBaseToListURL(t *testing.T) {
 	}
 	if !strings.Contains(listURL, "storage/v1/b/kubevirt-prow/o") {
 		t.Errorf("unexpected listURL: %s", listURL)
+	}
+	if !strings.Contains(listURL, "maxResults=500") {
+		t.Errorf("expected maxResults parameter in listURL: %s", listURL)
+	}
+	if !strings.Contains(listURL, "prefix=") {
+		t.Errorf("expected prefix parameter in listURL: %s", listURL)
 	}
 	if downloadBase != "https://storage.googleapis.com/kubevirt-prow/" {
 		t.Errorf("unexpected downloadBase: %s", downloadBase)

--- a/pkg/ci-failures/k8s_analyze_test.go
+++ b/pkg/ci-failures/k8s_analyze_test.go
@@ -469,6 +469,250 @@ func TestFetchEtcdProfileNotPresent(t *testing.T) {
 	}
 }
 
+func TestParseContainerLogFileName(t *testing.T) {
+	tests := []struct {
+		name          string
+		fileName      string
+		expectOK      bool
+		expectNS      string
+		expectPod     string
+		expectCont    string
+	}{
+		{
+			name:       "virt-controller log",
+			fileName:   "0_kubevirt_virt-controller-65cc5dc497-75jjr-virt-controller.log",
+			expectOK:   true,
+			expectNS:   "kubevirt",
+			expectPod:  "virt-controller-65cc5dc497-75jjr",
+			expectCont: "virt-controller",
+		},
+		{
+			name:       "virt-handler log",
+			fileName:   "0_kubevirt_virt-handler-7cdkk-virt-handler.log",
+			expectOK:   true,
+			expectNS:   "kubevirt",
+			expectPod:  "virt-handler-7cdkk",
+			expectCont: "virt-handler",
+		},
+		{
+			name:       "virt-api log",
+			fileName:   "0_kubevirt_virt-api-5bf5dd6df9-6nxcf-virt-api.log",
+			expectOK:   true,
+			expectNS:   "kubevirt",
+			expectPod:  "virt-api-5bf5dd6df9-6nxcf",
+			expectCont: "virt-api",
+		},
+		{
+			name:       "virt-operator log",
+			fileName:   "0_kubevirt_virt-operator-7b646765b4-4b2ks-virt-operator.log",
+			expectOK:   true,
+			expectNS:   "kubevirt",
+			expectPod:  "virt-operator-7b646765b4-4b2ks",
+			expectCont: "virt-operator",
+		},
+		{
+			name:     "previous log is skipped",
+			fileName: "0_kubevirt_virt-controller-65cc5dc497-75jjr-virt-controller_previous.log",
+			expectOK: false,
+		},
+		{
+			name:     "non-kubevirt component is skipped by caller",
+			fileName: "0_kube-system_coredns-64b977d65c-gkhvz-coredns.log",
+			expectOK: false,
+		},
+		{
+			name:     "object dump is not a container log",
+			fileName: "0_pods.log",
+			expectOK: false,
+		},
+		{
+			name:     "non-log file",
+			fileName: "0_pods.json",
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, ok := parseContainerLogFileName(tt.fileName)
+			if ok != tt.expectOK {
+				t.Fatalf("expected ok=%v, got %v", tt.expectOK, ok)
+			}
+			if !ok {
+				return
+			}
+			if meta.namespace != tt.expectNS {
+				t.Errorf("namespace: expected %q, got %q", tt.expectNS, meta.namespace)
+			}
+			if meta.podName != tt.expectPod {
+				t.Errorf("podName: expected %q, got %q", tt.expectPod, meta.podName)
+			}
+			if meta.containerName != tt.expectCont {
+				t.Errorf("containerName: expected %q, got %q", tt.expectCont, meta.containerName)
+			}
+		})
+	}
+}
+
+func TestListAndFilterContainerLogs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
+		resp := gcsListResponse{
+			Items: []struct {
+				Name string `json:"name"`
+				Size string `json:"size"`
+			}{
+				{Name: "prefix/suite/0_kubevirt_virt-controller-abc123-virt-controller.log", Size: "1000"},
+				{Name: "prefix/suite/0_kubevirt_virt-handler-xyz-virt-handler.log", Size: "2000"},
+				{Name: "prefix/suite/0_pods.log", Size: "5000"},
+				{Name: "prefix/suite/0_kube-system_coredns-abc-coredns.log", Size: "3000"},
+				{Name: "prefix/suite/0_kubevirt_virt-controller-abc123-virt-controller_previous.log", Size: "900"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	files := listAndFilterContainerLogs(server.URL+"/list", server.URL+"/")
+
+	if len(files) != 2 {
+		t.Fatalf("expected 2 container log files, got %d", len(files))
+	}
+
+	foundController := false
+	foundHandler := false
+	for _, f := range files {
+		if f.containerName == "virt-controller" {
+			foundController = true
+		}
+		if f.containerName == "virt-handler" {
+			foundHandler = true
+		}
+	}
+	if !foundController {
+		t.Error("expected virt-controller log")
+	}
+	if !foundHandler {
+		t.Error("expected virt-handler log")
+	}
+}
+
+func TestGcsBaseToListURL(t *testing.T) {
+	listURL, downloadBase := gcsBaseToListURL("https://storage.googleapis.com/kubevirt-prow/logs/job/123/artifacts/k8s-reporter/suite")
+	if listURL == "" {
+		t.Fatal("expected non-empty listURL")
+	}
+	if !strings.Contains(listURL, "storage/v1/b/kubevirt-prow/o") {
+		t.Errorf("unexpected listURL: %s", listURL)
+	}
+	if downloadBase != "https://storage.googleapis.com/kubevirt-prow/" {
+		t.Errorf("unexpected downloadBase: %s", downloadBase)
+	}
+
+	listURL, _ = gcsBaseToListURL("http://localhost:8080/test")
+	if listURL != "" {
+		t.Error("expected empty listURL for non-GCS URL")
+	}
+}
+
+func TestDownloadContainerLogCaching(t *testing.T) {
+	callCount := 0
+	logContent := "level=error msg=\"test error\"\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		fmt.Fprint(w, logContent)
+	}))
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	fileName := "0_kubevirt_virt-controller-abc-virt-controller.log"
+
+	path1, size1, err := downloadContainerLog(server.URL+"/log", cacheDir, fileName)
+	if err != nil {
+		t.Fatalf("first download failed: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", callCount)
+	}
+	if size1 != int64(len(logContent)) {
+		t.Errorf("expected size %d, got %d", len(logContent), size1)
+	}
+
+	path2, _, err := downloadContainerLog(server.URL+"/log", cacheDir, fileName)
+	if err != nil {
+		t.Fatalf("second download failed: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected cache hit (still 1 call), got %d", callCount)
+	}
+	if path1 != path2 {
+		t.Error("cached path should be the same")
+	}
+}
+
+func TestFetchContainerLogsEndToEnd(t *testing.T) {
+	logContent := "level=error msg=\"schema validation failed\"\n"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
+		resp := gcsListResponse{
+			Items: []struct {
+				Name string `json:"name"`
+				Size string `json:"size"`
+			}{
+				{Name: "suite/0_kubevirt_virt-controller-abc-virt-controller.log", Size: "100"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/suite/0_kubevirt_virt-controller-abc-virt-controller.log", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, logContent)
+	})
+	mux.HandleFunc("/", notFound)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cacheDir := t.TempDir()
+	logCacheDir := filepath.Join(cacheDir, "container-logs")
+	if err := os.MkdirAll(logCacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use listAndFilterContainerLogs directly, then download
+	files := listAndFilterContainerLogs(server.URL+"/list", server.URL+"/")
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file from listing, got %d", len(files))
+	}
+
+	f := files[0]
+	cached, size, err := downloadContainerLog(f.url, logCacheDir, f.fileName)
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	if f.containerName != "virt-controller" {
+		t.Errorf("expected container name 'virt-controller', got %q", f.containerName)
+	}
+	if f.namespace != "kubevirt" {
+		t.Errorf("expected namespace 'kubevirt', got %q", f.namespace)
+	}
+	if size != int64(len(logContent)) {
+		t.Errorf("expected size %d, got %d", len(logContent), size)
+	}
+
+	content, err := os.ReadFile(cached)
+	if err != nil {
+		t.Fatalf("failed to read cached file: %v", err)
+	}
+	if string(content) != logContent {
+		t.Errorf("cached content mismatch: got %q", string(content))
+	}
+}
+
 func ok(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/ci-failures/k8s_types.go
+++ b/pkg/ci-failures/k8s_types.go
@@ -195,17 +195,27 @@ type K8sFinding struct {
 	Snapshot  K8sSnapshot `yaml:"snapshot"`
 }
 
+// ContainerLogFile records a cached container log file for interactive grep.
+type ContainerLogFile struct {
+	PodName       string `yaml:"pod_name"`
+	ContainerName string `yaml:"container_name"`
+	Namespace     string `yaml:"namespace"`
+	CachedPath    string `yaml:"cached_path"`
+	SizeBytes     int64  `yaml:"size_bytes"`
+}
+
 // K8sAnalysisResult is the top-level output for analyze-k8s.
 type K8sAnalysisResult struct {
-	ProwJobURL  string               `yaml:"prow_job_url"`
-	JobName     string               `yaml:"job_name"`
-	BuildID     int                  `yaml:"build_id"`
-	Started     time.Time            `yaml:"started"`
-	Finished    time.Time            `yaml:"finished"`
-	Snapshots   []K8sSnapshot        `yaml:"snapshots"`
-	Findings    []*K8sFinding        `yaml:"findings"`
-	Summary     K8sSummary           `yaml:"summary"`
-	EtcdProfile *EtcdStorageProfile  `yaml:"etcd_profile,omitempty"`
+	ProwJobURL        string               `yaml:"prow_job_url"`
+	JobName           string               `yaml:"job_name"`
+	BuildID           int                  `yaml:"build_id"`
+	Started           time.Time            `yaml:"started"`
+	Finished          time.Time            `yaml:"finished"`
+	Snapshots         []K8sSnapshot        `yaml:"snapshots"`
+	Findings          []*K8sFinding        `yaml:"findings"`
+	Summary           K8sSummary           `yaml:"summary"`
+	EtcdProfile       *EtcdStorageProfile  `yaml:"etcd_profile,omitempty"`
+	ContainerLogFiles []ContainerLogFile   `yaml:"container_log_files,omitempty"`
 }
 
 // EtcdStorageProfile is the top-level structure of etcd-storage-profile.json


### PR DESCRIPTION
## Summary
- Download and cache virt-controller, virt-handler, virt-api, and virt-operator container logs from k8s-reporter suite artifacts during `analyze-build` and `analyze-pr` runs
- Enable cross-referencing failing VMI/VM names against component logs via `grep` to find schema validation errors, sync failures, and webhook rejections
- Update both `analyze-build` and `analyze-pr-builds` skill definitions with the new container log analysis step

## Motivation

Feedback on [kubevirt/kubevirt#17688](https://github.com/kubevirt/kubevirt/issues/17688): the VSOCK root cause was a CRD schema mismatch (`int32` vs `uint32`) causing the API server to reject status patches. This was only visible in **virt-controller logs** (`"the server rejected our request due to an error in our request"`), not in build logs or k8s object state. The skill's original hypothesis (device taints) was wrong because it lacked this signal.

## Test plan
- [x] Unit tests pass (`go test ./pkg/ci-failures/...`)
- [x] Verified against real build (periodic-kubevirt-e2e-k8s-1.36-sig-compute/2051152420498575360) — 8 container logs discovered and cached
- [x] `container_log_files` field present in output YAML with correct paths
- [x] `grep testvmi` on cached virt-controller logs returns relevant matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)