### PR TITLE
feat: add test-rate command for historical test success rates

### DIFF
--- a/.claude/skills/test-failure-rate/SKILL.md
+++ b/.claude/skills/test-failure-rate/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: test-failure-rate
+description: >
+    Show historical success rate for tests that failed in a build.
+    Use when the user wants to know if a test failure is flaky or PR-related.
+allowed-tools: [Read, Glob, Bash(go run:*)]
+---
+
+## Overview
+
+This skill looks up the historical success rate for each test that failed in a Prow build, using the kubevirt flakefinder 7-day (168h) report.
+
+## Data generation
+
+Run the `test-rate` subcommand with the Prow job URL:
+
+```bash
+$ go run ./cmd/ci-failures test-rate <prow-job-url>
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures test-rate https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
+```
+
+This produces `output/tmp/test-rate-{job-name}.yaml`.
+
+## Analysis
+
+After data generation:
+
+1. Use Glob to find the `output/tmp/test-rate-*.yaml` file
+2. Read the YAML. The structure is:
+   - `prow_job_url`: the analyzed build URL
+   - `job_name`: the Prow job name
+   - `report_period_end`: end date of the 7-day flakefinder report
+   - `failed_tests`: list of failed tests, each with:
+     - `test_name`: original test name from the build log
+     - `matched_name`: the matching test name in the flakefinder report (empty if no match)
+     - `total_succeeded`: total successes across all jobs in the 7-day period
+     - `total_failed`: total failures across all jobs
+     - `total_skipped`: total skips
+     - `success_rate`: percentage (0-100)
+     - `severity`: classification of the failure
+
+## Severity classification
+
+- **likely-pr-related** (success rate >= 95%): the test almost always passes, so this failure is probably caused by the PR's changes
+- **inconclusive** (success rate >= 80%): moderate flakiness, can't determine if PR-related
+- **likely-flaky** (success rate < 80%): the test fails frequently across all jobs, likely a known flake
+- **unknown**: the test was not found in the flakefinder report
+
+## Presenting results
+
+For each failed test, report:
+1. The test name
+2. The success rate and total runs (succeeded + failed)
+3. The severity classification
+4. If severity is "unknown", note that the test may be new or not covered by flakefinder

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -97,6 +97,21 @@ Accepts a Prow job URL, e.g.:
 		Args: cobra.ExactArgs(1),
 		RunE: analyzeK8s,
 	}
+
+	testRateCmd = &cobra.Command{
+		Use:   "test-rate [prow-job-url]",
+		Short: "Show historical success rate for tests that failed in a build.",
+		Long: `Look up historical success rates for each test that failed in a Prow build.
+
+Uses the kubevirt flakefinder 7-day (168h) report to compute per-test success
+rates across all jobs. Classifies each failure as likely-pr-related (>= 95%
+success rate), inconclusive (>= 80%), or likely-flaky (< 80%).
+
+Accepts a Prow job URL, e.g.:
+  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144`,
+		Args: cobra.ExactArgs(1),
+		RunE: testRate,
+	}
 )
 
 func generateReport(cmd *cobra.Command, args []string) error {
@@ -339,6 +354,27 @@ func analyzeK8s(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+func testRate(_ *cobra.Command, args []string) error {
+	prowJobURL := args[0]
+
+	result, err := cifailures.AnalyzeTestRate(prowJobURL)
+	if err != nil {
+		return fmt.Errorf("failed to analyze test rate: %v", err)
+	}
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("test-rate-%s.yaml", result.JobName))
+	if err = cifailures.WriteTestRateResultYAML(outputPath, result); err != nil {
+		return fmt.Errorf("failed to write YAML output: %v", err)
+	}
+
+	log.Infof("wrote test rate analysis to %s (%d tests)", outputPath, len(result.FailedTests))
+	return nil
+}
+
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
@@ -347,6 +383,7 @@ func init() {
 	rootCmd.AddCommand(analyzeBuildCmd)
 	rootCmd.AddCommand(analyzePRCmd)
 	rootCmd.AddCommand(analyzeK8sCmd)
+	rootCmd.AddCommand(testRateCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -1,0 +1,224 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+var flakefinderBaseURL = "https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt"
+
+type FlakefinderReport struct {
+	StartOfReport string                            `json:"startOfReport"`
+	EndOfReport   string                            `json:"endOfReport"`
+	Headers       []string                          `json:"headers"`
+	Tests         []string                          `json:"tests"`
+	Data          map[string]map[string]*TestDetails `json:"data"`
+}
+
+type TestDetails struct {
+	Succeeded int    `json:"succeeded"`
+	Failed    int    `json:"failed"`
+	Skipped   int    `json:"skipped"`
+	Severity  string `json:"severity"`
+}
+
+type TestRateResult struct {
+	ProwJobURL      string          `yaml:"prow_job_url"`
+	JobName         string          `yaml:"job_name"`
+	ReportPeriodEnd string          `yaml:"report_period_end"`
+	FailedTests     []TestRateEntry `yaml:"failed_tests"`
+}
+
+type TestRateEntry struct {
+	TestName       string  `yaml:"test_name"`
+	MatchedName    string  `yaml:"matched_name,omitempty"`
+	TotalSucceeded int     `yaml:"total_succeeded"`
+	TotalFailed    int     `yaml:"total_failed"`
+	TotalSkipped   int     `yaml:"total_skipped"`
+	SuccessRate    float64 `yaml:"success_rate"`
+	Severity       string  `yaml:"severity"`
+}
+
+func AnalyzeTestRate(prowJobURL string) (*TestRateResult, error) {
+	prowJobURL = normalizeJobURL(prowJobURL)
+
+	jobBuildErrors, err := AnalyzeBuild(prowJobURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to analyze build: %w", err)
+	}
+
+	failedTests := extractFailedTestNames(jobBuildErrors)
+	if len(failedTests) == 0 {
+		return nil, fmt.Errorf("no failed tests found in build log")
+	}
+
+	log.Infof("found %d failed test(s) in build log", len(failedTests))
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	report, err := fetchFlakefinderReport(yesterday)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch flakefinder report: %w", err)
+	}
+
+	log.Infof("fetched flakefinder report: %s to %s (%d tests)", report.StartOfReport, report.EndOfReport, len(report.Tests))
+
+	var entries []TestRateEntry
+	for _, testName := range failedTests {
+		entry := computeTestRate(testName, report)
+		entries = append(entries, entry)
+	}
+
+	return &TestRateResult{
+		ProwJobURL:      prowJobURL,
+		JobName:         jobBuildErrors.JobName,
+		ReportPeriodEnd: yesterday.Format(time.DateOnly),
+		FailedTests:     entries,
+	}, nil
+}
+
+var ginkgoFailLineRegex = regexp.MustCompile(`\[FAIL\]\s+(.+)$`)
+
+func extractFailedTestNames(jobBuildErrors *JobBuildErrors) []string {
+	seen := map[string]bool{}
+	var result []string
+
+	for _, buildErr := range jobBuildErrors.BuildErrors {
+		for _, snippet := range buildErr.BuildLogErrorSnippets {
+			text := stripTimestamp(snippet.ErrorText)
+			matches := ginkgoFailLineRegex.FindStringSubmatch(text)
+			if matches == nil {
+				continue
+			}
+			name := strings.TrimSpace(matches[1])
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			result = append(result, name)
+		}
+	}
+
+	return result
+}
+
+var timestampPrefixRegex = regexp.MustCompile(`^\d{2}:\d{2}:\d{2}:\s*`)
+
+func stripTimestamp(s string) string {
+	return timestampPrefixRegex.ReplaceAllString(strings.TrimSpace(s), "")
+}
+
+func fetchFlakefinderReport(date time.Time) (*FlakefinderReport, error) {
+	url := fmt.Sprintf("%s/flakefinder-%s-168h.json", flakefinderBaseURL, date.Format(time.DateOnly))
+	log.Infof("fetching flakefinder report from %s", url)
+
+	raw, err := retrieveFileContentFromGCS(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch flakefinder report: %w", err)
+	}
+
+	var report FlakefinderReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return nil, fmt.Errorf("failed to decode flakefinder JSON: %w", err)
+	}
+
+	return &report, nil
+}
+
+var (
+	itMarkerRegex       = regexp.MustCompile(`\s*\[It\]\s*`)
+	trailingLabelsRegex = regexp.MustCompile(`\s*\[[^\]]*,\s*[^\]]*\]\s*$`)
+)
+
+func normalizeTestName(raw string) string {
+	name := strings.TrimSpace(raw)
+	name = itMarkerRegex.ReplaceAllString(name, " ")
+	name = trailingLabelsRegex.ReplaceAllString(name, "")
+	return strings.TrimSpace(name)
+}
+
+func findMatchingTest(name string, report *FlakefinderReport) string {
+	normalized := normalizeTestName(name)
+
+	for _, candidate := range report.Tests {
+		if candidate == name {
+			return candidate
+		}
+	}
+
+	for _, candidate := range report.Tests {
+		if candidate == normalized {
+			return candidate
+		}
+	}
+
+	for _, candidate := range report.Tests {
+		if strings.Contains(candidate, normalized) || strings.Contains(normalized, candidate) {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+func computeTestRate(testName string, report *FlakefinderReport) TestRateEntry {
+	entry := TestRateEntry{
+		TestName: testName,
+		Severity: "unknown",
+	}
+
+	matched := findMatchingTest(testName, report)
+	if matched == "" {
+		log.Warnf("no flakefinder match for test: %s", testName)
+		return entry
+	}
+
+	entry.MatchedName = matched
+
+	jobData, ok := report.Data[matched]
+	if !ok {
+		return entry
+	}
+
+	for _, details := range jobData {
+		entry.TotalSucceeded += details.Succeeded
+		entry.TotalFailed += details.Failed
+		entry.TotalSkipped += details.Skipped
+	}
+
+	total := entry.TotalSucceeded + entry.TotalFailed
+	if total > 0 {
+		entry.SuccessRate = float64(entry.TotalSucceeded) / float64(total) * 100.0
+	}
+
+	switch {
+	case entry.SuccessRate >= 95:
+		entry.Severity = "likely-pr-related"
+	case entry.SuccessRate >= 80:
+		entry.Severity = "inconclusive"
+	default:
+		entry.Severity = "likely-flaky"
+	}
+
+	return entry
+}
+
+func WriteTestRateResultYAML(outputPath string, result *TestRateResult) error {
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
+	}
+	defer outputFile.Close()
+
+	encoder := yaml.NewEncoder(outputFile)
+	if err := encoder.Encode(result); err != nil {
+		return fmt.Errorf("failed to encode YAML: %v", err)
+	}
+	return nil
+}

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -61,8 +61,15 @@ func AnalyzeTestRate(prowJobURL string) (*TestRateResult, error) {
 
 	log.Infof("found %d failed test(s) in build log", len(failedTests))
 
-	yesterday := time.Now().UTC().AddDate(0, 0, -1)
-	report, err := fetchFlakefinderReport(yesterday)
+	var report *FlakefinderReport
+	var reportDate time.Time
+	for i := 1; i <= 3; i++ {
+		reportDate = time.Now().UTC().AddDate(0, 0, -i)
+		report, err = fetchFlakefinderReport(reportDate)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch flakefinder report: %w", err)
 	}
@@ -78,7 +85,7 @@ func AnalyzeTestRate(prowJobURL string) (*TestRateResult, error) {
 	return &TestRateResult{
 		ProwJobURL:      prowJobURL,
 		JobName:         jobBuildErrors.JobName,
-		ReportPeriodEnd: yesterday.Format(time.DateOnly),
+		ReportPeriodEnd: reportDate.Format(time.DateOnly),
 		FailedTests:     entries,
 	}, nil
 }
@@ -97,10 +104,11 @@ func extractFailedTestNames(jobBuildErrors *JobBuildErrors) []string {
 				continue
 			}
 			name := strings.TrimSpace(matches[1])
-			if name == "" || seen[name] {
+			norm := normalizeTestName(name)
+			if name == "" || seen[norm] {
 				continue
 			}
-			seen[name] = true
+			seen[norm] = true
 			result = append(result, name)
 		}
 	}

--- a/pkg/ci-failures/test_rate_test.go
+++ b/pkg/ci-failures/test_rate_test.go
@@ -1,0 +1,266 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStripTimestamp(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"13:34:47: [FAIL] some test", "[FAIL] some test"},
+		{"  13:34:47:  [FAIL] some test", "[FAIL] some test"},
+		{"[FAIL] no timestamp", "[FAIL] no timestamp"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := stripTimestamp(tt.input)
+		if got != tt.expected {
+			t.Errorf("stripTimestamp(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestNormalizeTestName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strips [It] marker",
+			input:    "[sig-compute] Live Migrations [It] with a live-migrate eviction strategy set",
+			expected: "[sig-compute] Live Migrations with a live-migrate eviction strategy set",
+		},
+		{
+			name:     "strips trailing labels",
+			input:    "[sig-compute] Live Migrations with a strategy set [sig-compute, sig-compute-migrations, Serial]",
+			expected: "[sig-compute] Live Migrations with a strategy set",
+		},
+		{
+			name:     "strips both [It] and trailing labels",
+			input:    "[sig-compute] Live Migrations [It] with a strategy set [sig-compute, sig-compute-migrations]",
+			expected: "[sig-compute] Live Migrations with a strategy set",
+		},
+		{
+			name:     "no-op for clean name",
+			input:    "[sig-compute] Live Migrations with a strategy set",
+			expected: "[sig-compute] Live Migrations with a strategy set",
+		},
+		{
+			name:     "does not strip single-element brackets",
+			input:    "[sig-compute] Live Migrations [rfe_id:393] with a strategy set",
+			expected: "[sig-compute] Live Migrations [rfe_id:393] with a strategy set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeTestName(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeTestName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindMatchingTest(t *testing.T) {
+	report := &FlakefinderReport{
+		Tests: []string{
+			"[sig-compute] Live Migrations with a live-migrate eviction strategy set",
+			"[sig-network] VMI connectivity should allow regular network traffic",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "exact match",
+			input:    "[sig-compute] Live Migrations with a live-migrate eviction strategy set",
+			expected: "[sig-compute] Live Migrations with a live-migrate eviction strategy set",
+		},
+		{
+			name:     "match after normalization (strip [It])",
+			input:    "[sig-compute] Live Migrations [It] with a live-migrate eviction strategy set",
+			expected: "[sig-compute] Live Migrations with a live-migrate eviction strategy set",
+		},
+		{
+			name:     "match after normalization (strip trailing labels)",
+			input:    "[sig-compute] Live Migrations with a live-migrate eviction strategy set [sig-compute, Serial]",
+			expected: "[sig-compute] Live Migrations with a live-migrate eviction strategy set",
+		},
+		{
+			name:     "no match",
+			input:    "[sig-storage] something completely different",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findMatchingTest(tt.input, report)
+			if got != tt.expected {
+				t.Errorf("findMatchingTest() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestComputeTestRate(t *testing.T) {
+	report := &FlakefinderReport{
+		Tests: []string{
+			"[sig-compute] Live Migrations with a strategy set",
+		},
+		Data: map[string]map[string]*TestDetails{
+			"[sig-compute] Live Migrations with a strategy set": {
+				"job-a": {Succeeded: 80, Failed: 10, Skipped: 5},
+				"job-b": {Succeeded: 70, Failed: 20, Skipped: 3},
+			},
+		},
+	}
+
+	entry := computeTestRate("[sig-compute] Live Migrations with a strategy set", report)
+
+	if entry.TotalSucceeded != 150 {
+		t.Errorf("TotalSucceeded = %d, want 150", entry.TotalSucceeded)
+	}
+	if entry.TotalFailed != 30 {
+		t.Errorf("TotalFailed = %d, want 30", entry.TotalFailed)
+	}
+	if entry.TotalSkipped != 8 {
+		t.Errorf("TotalSkipped = %d, want 8", entry.TotalSkipped)
+	}
+
+	expectedRate := float64(150) / float64(180) * 100.0
+	if entry.SuccessRate != expectedRate {
+		t.Errorf("SuccessRate = %f, want %f", entry.SuccessRate, expectedRate)
+	}
+	if entry.Severity != "inconclusive" {
+		t.Errorf("Severity = %q, want %q", entry.Severity, "inconclusive")
+	}
+}
+
+func TestComputeTestRateNoMatch(t *testing.T) {
+	report := &FlakefinderReport{
+		Tests: []string{"[sig-compute] something else"},
+		Data:  map[string]map[string]*TestDetails{},
+	}
+
+	entry := computeTestRate("[sig-storage] unknown test", report)
+
+	if entry.MatchedName != "" {
+		t.Errorf("MatchedName = %q, want empty", entry.MatchedName)
+	}
+	if entry.Severity != "unknown" {
+		t.Errorf("Severity = %q, want %q", entry.Severity, "unknown")
+	}
+}
+
+func TestComputeTestRateSeverityBuckets(t *testing.T) {
+	tests := []struct {
+		name             string
+		succeeded        int
+		failed           int
+		expectedSeverity string
+	}{
+		{"high success rate", 98, 2, "likely-pr-related"},
+		{"exactly 95%", 95, 5, "likely-pr-related"},
+		{"moderate success rate", 85, 15, "inconclusive"},
+		{"exactly 80%", 80, 20, "inconclusive"},
+		{"low success rate", 60, 40, "likely-flaky"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testName := "[sig-compute] test"
+			report := &FlakefinderReport{
+				Tests: []string{testName},
+				Data: map[string]map[string]*TestDetails{
+					testName: {
+						"job-a": {Succeeded: tt.succeeded, Failed: tt.failed},
+					},
+				},
+			}
+
+			entry := computeTestRate(testName, report)
+			if entry.Severity != tt.expectedSeverity {
+				t.Errorf("Severity = %q, want %q (rate=%.1f%%)", entry.Severity, tt.expectedSeverity, entry.SuccessRate)
+			}
+		})
+	}
+}
+
+func TestExtractFailedTestNames(t *testing.T) {
+	jobBuildErrors := &JobBuildErrors{
+		BuildErrors: []*JobBuildError{
+			{
+				BuildLogErrorSnippets: []*BuildLogErrorSnippet{
+					{ErrorText: "13:34:47: [FAIL] [sig-compute] Live Migrations [It] with a strategy set [sig-compute, Serial]"},
+					{ErrorText: "some other error without FAIL marker"},
+					{ErrorText: "[FAIL] [sig-network] VMI connectivity [It] should work [sig-network]"},
+					{ErrorText: "13:34:47: [FAIL] [sig-compute] Live Migrations [It] with a strategy set [sig-compute, Serial]"},
+				},
+			},
+		},
+	}
+
+	result := extractFailedTestNames(jobBuildErrors)
+
+	if len(result) != 2 {
+		t.Fatalf("got %d test names, want 2", len(result))
+	}
+	if result[0] != "[sig-compute] Live Migrations [It] with a strategy set [sig-compute, Serial]" {
+		t.Errorf("result[0] = %q, unexpected", result[0])
+	}
+	if result[1] != "[sig-network] VMI connectivity [It] should work [sig-network]" {
+		t.Errorf("result[1] = %q, unexpected", result[1])
+	}
+}
+
+func TestFetchFlakefinderReport(t *testing.T) {
+	report := FlakefinderReport{
+		StartOfReport: "2026-05-03",
+		EndOfReport:   "2026-05-10",
+		Headers:       []string{"job-a", "job-b"},
+		Tests:         []string{"[sig-compute] test one"},
+		Data: map[string]map[string]*TestDetails{
+			"[sig-compute] test one": {
+				"job-a": {Succeeded: 90, Failed: 10, Skipped: 0, Severity: "yellow"},
+			},
+		},
+	}
+
+	reportJSON, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(reportJSON)
+	}))
+	defer server.Close()
+
+	origBase := flakefinderBaseURL
+	defer func() { flakefinderBaseURL = origBase }()
+	flakefinderBaseURL = server.URL
+
+	date := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
+	result, err := fetchFlakefinderReport(date)
+	if err != nil {
+		t.Fatalf("fetchFlakefinderReport() error: %v", err)
+	}
+
+	if result.StartOfReport != "2026-05-03" {
+		t.Errorf("StartOfReport = %q, want %q", result.StartOfReport, "2026-05-03")
+	}
+	if len(result.Tests) != 1 {
+		t.Errorf("len(Tests) = %d, want 1", len(result.Tests))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `test-rate` subcommand that looks up historical success rates for tests that failed in a Prow build
- Uses kubevirt flakefinder 7-day (168h) reports to compute per-test success rates across all jobs
- Classifies failures as **likely-pr-related** (>= 95%), **inconclusive** (>= 80%), or **likely-flaky** (< 80%)
- Normalizes test names (strips `[It]` markers, timestamps, trailing label lists) for fuzzy matching against flakefinder data

## Test plan

- [x] Unit tests pass (`go test ./pkg/ci-failures/...`)
- [x] Verified against real build: [pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144)
- [x] Output YAML contains correct success rate (88.9% for the migration test, classified as inconclusive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)