### PR TITLE
feat: add --days flag to test-rate for extended time periods

### DIFF
--- a/.claude/skills/test-failure-rate/SKILL.md
+++ b/.claude/skills/test-failure-rate/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: [Read, Glob, Bash(go run:*)]
 
 ## Overview
 
-This skill looks up the historical success rate for each test that failed in a Prow build, using the kubevirt flakefinder 7-day (168h) report.
+This skill looks up the historical success rate for each test that failed in a Prow build, using kubevirt flakefinder 7-day (168h) reports. Use `--days` to extend the analysis window up to 28 days by fetching and merging multiple weekly reports.
 
 ## Data generation
 
@@ -18,10 +18,16 @@ Run the `test-rate` subcommand with the Prow job URL:
 $ go run ./cmd/ci-failures test-rate <prow-job-url>
 ```
 
+To cover a longer period (up to 28 days):
+
+```bash
+$ go run ./cmd/ci-failures test-rate --days 14 <prow-job-url>
+```
+
 Example:
 
 ```bash
-$ go run ./cmd/ci-failures test-rate https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
+$ go run ./cmd/ci-failures test-rate --days 21 https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
 ```
 
 This produces `output/tmp/test-rate-{job-name}.yaml`.
@@ -34,11 +40,13 @@ After data generation:
 2. Read the YAML. The structure is:
    - `prow_job_url`: the analyzed build URL
    - `job_name`: the Prow job name
-   - `report_period_end`: end date of the 7-day flakefinder report
+   - `report_days`: number of days covered
+   - `report_period_start`: start date of the merged flakefinder window
+   - `report_period_end`: end date of the merged flakefinder window
    - `failed_tests`: list of failed tests, each with:
      - `test_name`: original test name from the build log
      - `matched_name`: the matching test name in the flakefinder report (empty if no match)
-     - `total_succeeded`: total successes across all jobs in the 7-day period
+     - `total_succeeded`: total successes across all jobs in the covered period
      - `total_failed`: total failures across all jobs
      - `total_skipped`: total skips
      - `success_rate`: percentage (0-100)

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -98,14 +98,19 @@ Accepts a Prow job URL, e.g.:
 		RunE: analyzeK8s,
 	}
 
+	testRateDays int
+
 	testRateCmd = &cobra.Command{
 		Use:   "test-rate [prow-job-url]",
 		Short: "Show historical success rate for tests that failed in a build.",
 		Long: `Look up historical success rates for each test that failed in a Prow build.
 
-Uses the kubevirt flakefinder 7-day (168h) report to compute per-test success
-rates across all jobs. Classifies each failure as likely-pr-related (>= 95%
-success rate), inconclusive (>= 80%), or likely-flaky (< 80%).
+Uses kubevirt flakefinder 7-day (168h) reports to compute per-test success
+rates across all jobs. Use --days to extend the analysis period up to 28 days
+by fetching and merging multiple weekly reports.
+
+Classifies each failure as likely-pr-related (>= 95% success rate),
+inconclusive (>= 80%), or likely-flaky (< 80%).
 
 Accepts a Prow job URL, e.g.:
   https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144`,
@@ -357,7 +362,7 @@ func analyzeK8s(_ *cobra.Command, args []string) error {
 func testRate(_ *cobra.Command, args []string) error {
 	prowJobURL := args[0]
 
-	result, err := cifailures.AnalyzeTestRate(prowJobURL)
+	result, err := cifailures.AnalyzeTestRate(prowJobURL, testRateDays)
 	if err != nil {
 		return fmt.Errorf("failed to analyze test rate: %v", err)
 	}
@@ -378,6 +383,8 @@ func testRate(_ *cobra.Command, args []string) error {
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
+
+	testRateCmd.Flags().IntVar(&testRateDays, "days", 7, "Number of days to cover (max 28, fetches multiple weekly reports)")
 
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(analyzeBuildCmd)

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -151,12 +151,12 @@ func fetchFlakefinderReports(days int) ([]*FlakefinderReport, error) {
 	numReports := int(math.Ceil(float64(days) / 7.0))
 	var reports []*FlakefinderReport
 
+	anchorDate := time.Now().UTC().AddDate(0, 0, -1)
 	for r := range numReports {
-		baseOffset := r * 7
 		var report *FlakefinderReport
 		var err error
-		for try := 1; try <= 3; try++ {
-			date := time.Now().UTC().AddDate(0, 0, -(baseOffset + try))
+		for try := range 3 {
+			date := anchorDate.AddDate(0, 0, -try)
 			report, err = fetchFlakefinderReport(date)
 			if err == nil {
 				break
@@ -166,6 +166,12 @@ func fetchFlakefinderReports(days int) ([]*FlakefinderReport, error) {
 			return nil, fmt.Errorf("failed to fetch flakefinder report for period %d: %w", r+1, err)
 		}
 		reports = append(reports, report)
+
+		if start, parseErr := time.Parse(time.DateOnly, report.StartOfReport); parseErr == nil {
+			anchorDate = start
+		} else {
+			anchorDate = anchorDate.AddDate(0, 0, -7)
+		}
 	}
 
 	return reports, nil

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -3,6 +3,7 @@ package cifailures
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
+
+const maxDays = 28
 
 var flakefinderBaseURL = "https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt"
 
@@ -30,10 +33,12 @@ type TestDetails struct {
 }
 
 type TestRateResult struct {
-	ProwJobURL      string          `yaml:"prow_job_url"`
-	JobName         string          `yaml:"job_name"`
-	ReportPeriodEnd string          `yaml:"report_period_end"`
-	FailedTests     []TestRateEntry `yaml:"failed_tests"`
+	ProwJobURL        string          `yaml:"prow_job_url"`
+	JobName           string          `yaml:"job_name"`
+	ReportDays        int             `yaml:"report_days"`
+	ReportPeriodStart string          `yaml:"report_period_start"`
+	ReportPeriodEnd   string          `yaml:"report_period_end"`
+	FailedTests       []TestRateEntry `yaml:"failed_tests"`
 }
 
 type TestRateEntry struct {
@@ -46,8 +51,15 @@ type TestRateEntry struct {
 	Severity       string  `yaml:"severity"`
 }
 
-func AnalyzeTestRate(prowJobURL string) (*TestRateResult, error) {
+func AnalyzeTestRate(prowJobURL string, days int) (*TestRateResult, error) {
 	prowJobURL = normalizeJobURL(prowJobURL)
+
+	if days < 1 {
+		days = 7
+	}
+	if days > maxDays {
+		days = maxDays
+	}
 
 	jobBuildErrors, err := AnalyzeBuild(prowJobURL)
 	if err != nil {
@@ -61,32 +73,28 @@ func AnalyzeTestRate(prowJobURL string) (*TestRateResult, error) {
 
 	log.Infof("found %d failed test(s) in build log", len(failedTests))
 
-	var report *FlakefinderReport
-	var reportDate time.Time
-	for i := 1; i <= 3; i++ {
-		reportDate = time.Now().UTC().AddDate(0, 0, -i)
-		report, err = fetchFlakefinderReport(reportDate)
-		if err == nil {
-			break
-		}
-	}
+	reports, err := fetchFlakefinderReports(days)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch flakefinder report: %w", err)
+		return nil, fmt.Errorf("failed to fetch flakefinder reports: %w", err)
 	}
 
-	log.Infof("fetched flakefinder report: %s to %s (%d tests)", report.StartOfReport, report.EndOfReport, len(report.Tests))
+	merged := mergeReports(reports)
+
+	log.Infof("merged %d flakefinder report(s) covering %s to %s (%d tests)", len(reports), merged.StartOfReport, merged.EndOfReport, len(merged.Tests))
 
 	var entries []TestRateEntry
 	for _, testName := range failedTests {
-		entry := computeTestRate(testName, report)
+		entry := computeTestRate(testName, merged)
 		entries = append(entries, entry)
 	}
 
 	return &TestRateResult{
-		ProwJobURL:      prowJobURL,
-		JobName:         jobBuildErrors.JobName,
-		ReportPeriodEnd: reportDate.Format(time.DateOnly),
-		FailedTests:     entries,
+		ProwJobURL:        prowJobURL,
+		JobName:           jobBuildErrors.JobName,
+		ReportDays:        days,
+		ReportPeriodStart: merged.StartOfReport,
+		ReportPeriodEnd:   merged.EndOfReport,
+		FailedTests:       entries,
 	}, nil
 }
 
@@ -137,6 +145,91 @@ func fetchFlakefinderReport(date time.Time) (*FlakefinderReport, error) {
 	}
 
 	return &report, nil
+}
+
+func fetchFlakefinderReports(days int) ([]*FlakefinderReport, error) {
+	numReports := int(math.Ceil(float64(days) / 7.0))
+	var reports []*FlakefinderReport
+
+	for r := range numReports {
+		baseOffset := r * 7
+		var report *FlakefinderReport
+		var err error
+		for try := 1; try <= 3; try++ {
+			date := time.Now().UTC().AddDate(0, 0, -(baseOffset + try))
+			report, err = fetchFlakefinderReport(date)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch flakefinder report for period %d: %w", r+1, err)
+		}
+		reports = append(reports, report)
+	}
+
+	return reports, nil
+}
+
+func mergeReports(reports []*FlakefinderReport) *FlakefinderReport {
+	if len(reports) == 1 {
+		return reports[0]
+	}
+
+	merged := &FlakefinderReport{
+		StartOfReport: reports[0].StartOfReport,
+		EndOfReport:   reports[0].EndOfReport,
+		Data:          make(map[string]map[string]*TestDetails),
+	}
+
+	testSet := map[string]bool{}
+	headerSet := map[string]bool{}
+
+	for _, r := range reports {
+		if r.StartOfReport < merged.StartOfReport {
+			merged.StartOfReport = r.StartOfReport
+		}
+		if r.EndOfReport > merged.EndOfReport {
+			merged.EndOfReport = r.EndOfReport
+		}
+
+		for _, h := range r.Headers {
+			if !headerSet[h] {
+				headerSet[h] = true
+				merged.Headers = append(merged.Headers, h)
+			}
+		}
+
+		for _, t := range r.Tests {
+			if !testSet[t] {
+				testSet[t] = true
+				merged.Tests = append(merged.Tests, t)
+			}
+		}
+
+		for testName, jobData := range r.Data {
+			if merged.Data[testName] == nil {
+				merged.Data[testName] = make(map[string]*TestDetails)
+			}
+			for jobName, details := range jobData {
+				existing, ok := merged.Data[testName][jobName]
+				if !ok {
+					merged.Data[testName][jobName] = &TestDetails{
+						Succeeded: details.Succeeded,
+						Failed:    details.Failed,
+						Skipped:   details.Skipped,
+						Severity:  details.Severity,
+					}
+				} else {
+					existing.Succeeded += details.Succeeded
+					existing.Failed += details.Failed
+					existing.Skipped += details.Skipped
+				}
+			}
+		}
+	}
+
+	return merged
 }
 
 var (

--- a/pkg/ci-failures/test_rate_test.go
+++ b/pkg/ci-failures/test_rate_test.go
@@ -223,6 +223,118 @@ func TestExtractFailedTestNames(t *testing.T) {
 	}
 }
 
+func TestMergeReports(t *testing.T) {
+	r1 := &FlakefinderReport{
+		StartOfReport: "2026-04-26",
+		EndOfReport:   "2026-05-03",
+		Headers:       []string{"job-a", "job-b"},
+		Tests:         []string{"[sig-compute] test one", "[sig-compute] test two"},
+		Data: map[string]map[string]*TestDetails{
+			"[sig-compute] test one": {
+				"job-a": {Succeeded: 50, Failed: 10, Skipped: 2},
+			},
+			"[sig-compute] test two": {
+				"job-b": {Succeeded: 30, Failed: 5, Skipped: 1},
+			},
+		},
+	}
+	r2 := &FlakefinderReport{
+		StartOfReport: "2026-05-03",
+		EndOfReport:   "2026-05-10",
+		Headers:       []string{"job-a", "job-c"},
+		Tests:         []string{"[sig-compute] test one", "[sig-network] test three"},
+		Data: map[string]map[string]*TestDetails{
+			"[sig-compute] test one": {
+				"job-a": {Succeeded: 40, Failed: 8, Skipped: 3},
+			},
+			"[sig-network] test three": {
+				"job-c": {Succeeded: 20, Failed: 2, Skipped: 0},
+			},
+		},
+	}
+
+	merged := mergeReports([]*FlakefinderReport{r1, r2})
+
+	if merged.StartOfReport != "2026-04-26" {
+		t.Errorf("StartOfReport = %q, want %q", merged.StartOfReport, "2026-04-26")
+	}
+	if merged.EndOfReport != "2026-05-10" {
+		t.Errorf("EndOfReport = %q, want %q", merged.EndOfReport, "2026-05-10")
+	}
+	if len(merged.Tests) != 3 {
+		t.Fatalf("len(Tests) = %d, want 3", len(merged.Tests))
+	}
+
+	d := merged.Data["[sig-compute] test one"]["job-a"]
+	if d == nil {
+		t.Fatal("missing data for test one / job-a")
+	}
+	if d.Succeeded != 90 {
+		t.Errorf("test one job-a Succeeded = %d, want 90", d.Succeeded)
+	}
+	if d.Failed != 18 {
+		t.Errorf("test one job-a Failed = %d, want 18", d.Failed)
+	}
+	if d.Skipped != 5 {
+		t.Errorf("test one job-a Skipped = %d, want 5", d.Skipped)
+	}
+
+	if _, ok := merged.Data["[sig-compute] test two"]["job-b"]; !ok {
+		t.Error("missing data for test two / job-b")
+	}
+	if _, ok := merged.Data["[sig-network] test three"]["job-c"]; !ok {
+		t.Error("missing data for test three / job-c")
+	}
+}
+
+func TestMergeReportsSingle(t *testing.T) {
+	r := &FlakefinderReport{
+		StartOfReport: "2026-05-03",
+		EndOfReport:   "2026-05-10",
+		Tests:         []string{"test"},
+		Data:          map[string]map[string]*TestDetails{},
+	}
+	merged := mergeReports([]*FlakefinderReport{r})
+	if merged != r {
+		t.Error("single report merge should return the same pointer")
+	}
+}
+
+func TestFetchFlakefinderReports(t *testing.T) {
+	reports := map[string]*FlakefinderReport{
+		"week1": {StartOfReport: "2026-05-03", EndOfReport: "2026-05-10", Tests: []string{"t1"}, Data: map[string]map[string]*TestDetails{}},
+		"week2": {StartOfReport: "2026-04-26", EndOfReport: "2026-05-03", Tests: []string{"t2"}, Data: map[string]map[string]*TestDetails{}},
+	}
+
+	served := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		for label, report := range reports {
+			if !served[label] {
+				served[label] = true
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(report)
+				return
+			}
+			_ = path
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	origBase := flakefinderBaseURL
+	defer func() { flakefinderBaseURL = origBase }()
+	flakefinderBaseURL = server.URL
+
+	result, err := fetchFlakefinderReports(14)
+	if err != nil {
+		t.Fatalf("fetchFlakefinderReports(14) error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("got %d reports, want 2", len(result))
+	}
+}
+
 func TestFetchFlakefinderReport(t *testing.T) {
 	report := FlakefinderReport{
 		StartOfReport: "2026-05-03",

--- a/pkg/ci-failures/test_rate_test.go
+++ b/pkg/ci-failures/test_rate_test.go
@@ -2,6 +2,7 @@ package cifailures
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -301,22 +302,32 @@ func TestMergeReportsSingle(t *testing.T) {
 }
 
 func TestFetchFlakefinderReports(t *testing.T) {
-	reports := map[string]*FlakefinderReport{
-		"week1": {StartOfReport: "2026-05-03", EndOfReport: "2026-05-10", Tests: []string{"t1"}, Data: map[string]map[string]*TestDetails{}},
-		"week2": {StartOfReport: "2026-04-26", EndOfReport: "2026-05-03", Tests: []string{"t2"}, Data: map[string]map[string]*TestDetails{}},
+	reportsByDate := map[string]*FlakefinderReport{}
+
+	now := time.Now().UTC()
+	week1Date := now.AddDate(0, 0, -1).Format(time.DateOnly)
+	reportsByDate[week1Date] = &FlakefinderReport{
+		StartOfReport: now.AddDate(0, 0, -8).Format(time.DateOnly),
+		EndOfReport:   week1Date,
+		Tests:         []string{"t1"},
+		Data:          map[string]map[string]*TestDetails{},
+	}
+	week2Date := now.AddDate(0, 0, -8).Format(time.DateOnly)
+	reportsByDate[week2Date] = &FlakefinderReport{
+		StartOfReport: now.AddDate(0, 0, -15).Format(time.DateOnly),
+		EndOfReport:   week2Date,
+		Tests:         []string{"t2"},
+		Data:          map[string]map[string]*TestDetails{},
 	}
 
-	served := map[string]bool{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		for label, report := range reports {
-			if !served[label] {
-				served[label] = true
+		for date, report := range reportsByDate {
+			expected := fmt.Sprintf("/flakefinder-%s-168h.json", date)
+			if r.URL.Path == expected {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(report)
 				return
 			}
-			_ = path
 		}
 		http.NotFound(w, r)
 	}))


### PR DESCRIPTION
## Summary

- Adds `--days` flag to `test-rate` command (default 7, max 28) to extend the flakefinder analysis window beyond a single 7-day report
- Fetches multiple weekly (168h) flakefinder reports at 7-day intervals and merges them, summing succeeded/failed/skipped counts per test
- Adds `report_days` and `report_period_start` fields to YAML output to reflect the full merged window

## Test plan

- [x] `go build ./cmd/ci-failures` compiles
- [x] `go vet ./...` passes
- [x] `go test ./pkg/ci-failures/...` — all existing and new tests pass (TestMergeReports, TestMergeReportsSingle, TestFetchFlakefinderReports)
- [x] Manual: `go run ./cmd/ci-failures test-rate --days 28 <prow-job-url>` fetches 4 reports and produces correct merged output

🤖 Generated with [Claude Code](https://claude.com/claude-code)