### PR TITLE
feat: add change-relevance subcommand

### DIFF
--- a/.claude/skills/change-relevance/SKILL.md
+++ b/.claude/skills/change-relevance/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: change-relevance
+description: >
+    Determine whether a PR's code changes are related to tests that failed in a Prow build.
+    Use when user wants to know if test failures are caused by their PR changes.
+allowed-tools: [Read, Glob, Bash(go run:*)]
+---
+
+## Overview
+
+This skill checks whether a PR's changed files overlap with the code areas that failing tests cover. It extracts the PR number from the Prow job URL, fetches the changed files from GitHub, maps each failed test to source directories via its SIG label, and reports whether the changes are related.
+
+## Data generation
+
+Run the `change-relevance` subcommand with a Prow job URL for a **PR build**:
+
+```bash
+$ go run ./cmd/ci-failures change-relevance <prow-job-url>
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures change-relevance https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17760/pull-kubevirt-e2e-kind-1.35-sig-compute-arm64/2053843644594524160
+```
+
+This produces `output/tmp/change-relevance-{job-name}.yaml`.
+
+Only PR builds (URLs containing `pr-logs/pull/`) are supported. Periodic builds will return an error.
+
+## Analysis
+
+After data generation:
+
+1. Use Glob to find the `output/tmp/change-relevance-*.yaml` file
+2. Read the YAML. The structure is:
+   - `prow_job_url`: the analyzed build URL
+   - `job_name`: the Prow job name
+   - `org`, `repo`, `pr_number`: the GitHub PR identity
+   - `changed_files`: list of files changed in the PR
+   - `failed_tests`: list of failed tests, each with:
+     - `test_name`: original test name from the build log
+     - `sig`: the SIG label extracted from the test name (or inferred from job name)
+     - `code_areas`: source directory prefixes mapped to that SIG
+     - `overlap_files`: PR files that overlap with the test's code areas (empty if none)
+     - `relevance`: classification of the relationship
+     - `reason`: human-readable explanation
+   - `summary`: aggregate counts of each relevance level
+
+## Relevance classification
+
+- **related**: The PR directly changes files in the SIG's code areas. The test failure is likely caused by the PR.
+- **possibly-related**: The PR changes broad-impact files (API definitions, shared utilities, test framework) that could affect any test. Cannot rule out the PR as the cause.
+- **unrelated**: The PR does not change any files in the test's code areas or in broad-impact areas. The failure is likely a pre-existing flake.
+- **unknown**: The test has no SIG label and the SIG could not be inferred from the job name, or the SIG is not in the mapping.
+
+## Presenting results
+
+For each failed test, report:
+1. The test name
+2. The SIG and relevance classification
+3. If related or possibly-related, list the overlapping files
+4. If unrelated, note that the failure is likely a flake
+
+Summarize with the aggregate counts from the `summary` section.
+
+## Combining with test-failure-rate
+
+For the most complete picture, run both `change-relevance` and `test-rate` on the same Prow job URL. Together they answer:
+- **test-rate**: Is this test historically flaky?
+- **change-relevance**: Did this PR touch the code the test covers?
+
+A test that is "likely-pr-related" by success rate AND "related" by change analysis is very likely caused by the PR.

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -78,6 +78,19 @@ Only repos served by prow.ci.kubevirt.io are supported.`,
 		RunE: analyzePR,
 	}
 
+	changeRelevanceCmd = &cobra.Command{
+		Use:   "change-relevance [prow-job-url]",
+		Short: "Check whether PR changes overlap with failed test code areas.",
+		Long: `Determine whether a PR's code changes are related to tests that failed in a Prow build.
+
+Accepts a Prow job URL for a PR build, e.g.:
+  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17760/pull-kubevirt-e2e-kind-1.35-sig-compute-arm64/2053843644594524160
+
+Only PR builds (URLs containing pr-logs/pull/) are supported.`,
+		Args: cobra.ExactArgs(1),
+		RunE: changeRelevance,
+	}
+
 	analyzeK8sCmd = &cobra.Command{
 		Use:   "analyze-k8s [prow-job-url]",
 		Short: "Analyze Kubernetes cluster state from k8s-reporter artifacts.",
@@ -380,6 +393,27 @@ func testRate(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+func changeRelevance(_ *cobra.Command, args []string) error {
+	prowJobURL := args[0]
+
+	result, err := cifailures.AnalyzeChangeRelevance(prowJobURL)
+	if err != nil {
+		return fmt.Errorf("failed to analyze change relevance: %v", err)
+	}
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("change-relevance-%s.yaml", result.JobName))
+	if err = cifailures.WriteChangeRelevanceResultYAML(outputPath, result); err != nil {
+		return fmt.Errorf("failed to write YAML output: %v", err)
+	}
+
+	log.Infof("wrote change relevance analysis to %s", outputPath)
+	return nil
+}
+
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
@@ -391,6 +425,7 @@ func init() {
 	rootCmd.AddCommand(analyzePRCmd)
 	rootCmd.AddCommand(analyzeK8sCmd)
 	rootCmd.AddCommand(testRateCmd)
+	rootCmd.AddCommand(changeRelevanceCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/ci-failures/change_relevance.go
+++ b/pkg/ci-failures/change_relevance.go
@@ -1,0 +1,349 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+var githubAPIBaseURL = "https://api.github.com"
+
+type ProwJobPR struct {
+	Org      string
+	Repo     string
+	PRNumber int
+}
+
+type ChangeRelevanceResult struct {
+	ProwJobURL   string                 `yaml:"prow_job_url"`
+	JobName      string                 `yaml:"job_name"`
+	Org          string                 `yaml:"org"`
+	Repo         string                 `yaml:"repo"`
+	PRNumber     int                    `yaml:"pr_number"`
+	ChangedFiles []string               `yaml:"changed_files"`
+	FailedTests  []ChangeRelevanceEntry `yaml:"failed_tests"`
+	Summary      RelevanceSummary       `yaml:"summary"`
+}
+
+type ChangeRelevanceEntry struct {
+	TestName     string   `yaml:"test_name"`
+	SIG          string   `yaml:"sig,omitempty"`
+	CodeAreas    []string `yaml:"code_areas,omitempty"`
+	OverlapFiles []string `yaml:"overlap_files,omitempty"`
+	Relevance    string   `yaml:"relevance"`
+	Reason       string   `yaml:"reason"`
+}
+
+type RelevanceSummary struct {
+	TotalFailedTests int `yaml:"total_failed_tests"`
+	Related          int `yaml:"related"`
+	PossiblyRelated  int `yaml:"possibly_related"`
+	Unrelated        int `yaml:"unrelated"`
+	Unknown          int `yaml:"unknown"`
+}
+
+var sigCodeAreas = map[string][]string{
+	"sig-compute": {
+		"pkg/virt-handler/",
+		"pkg/virt-launcher/",
+		"pkg/virt-controller/",
+		"pkg/virt-api/",
+		"pkg/libvmi/",
+		"pkg/executor/",
+		"pkg/hypervisor/",
+		"cmd/virt-handler/",
+		"cmd/virt-launcher/",
+		"cmd/virt-controller/",
+		"cmd/virt-api/",
+		"tests/compute/",
+	},
+	"sig-network": {
+		"pkg/network/",
+		"tests/network/",
+		"tests/libnet/",
+	},
+	"sig-storage": {
+		"pkg/storage/",
+		"pkg/container-disk/",
+		"pkg/hotplug-disk/",
+		"tests/storage/",
+		"tests/libstorage/",
+	},
+	"sig-compute-migrations": {
+		"pkg/virt-handler/migration/",
+		"pkg/virt-controller/watch/migration",
+		"tests/migration/",
+		"tests/libmigration/",
+	},
+	"sig-operator": {
+		"pkg/virt-operator/",
+		"pkg/virt-controller/",
+		"pkg/config/",
+		"tests/operator/",
+	},
+	"sig-monitoring": {
+		"pkg/monitoring/",
+		"tests/monitoring/",
+		"tests/libmonitoring/",
+	},
+}
+
+var broadChangeAreas = []string{
+	"staging/src/kubevirt.io/api/",
+	"staging/src/kubevirt.io/client-go/",
+	"pkg/util/",
+	"tests/framework/",
+	"tests/libvmi/",
+	"tests/testsuite/",
+	"hack/",
+	"Makefile",
+	"go.mod",
+	"go.sum",
+}
+
+const prowPRLogsMarker = "/pr-logs/pull/"
+
+func ParseProwJobPR(prowJobURL string) (*ProwJobPR, error) {
+	url := normalizeJobURL(prowJobURL)
+
+	idx := strings.Index(url, prowPRLogsMarker)
+	if idx < 0 {
+		return nil, fmt.Errorf("URL is not a PR build (no pr-logs/pull/ segment): %s", url)
+	}
+
+	remainder := url[idx+len(prowPRLogsMarker):]
+	parts := strings.Split(remainder, "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("malformed Prow PR URL, expected {org}_{repo}/{pr}/...: %s", url)
+	}
+
+	orgRepo := parts[0]
+	sepIdx := strings.Index(orgRepo, "_")
+	if sepIdx < 1 || sepIdx >= len(orgRepo)-1 {
+		return nil, fmt.Errorf("malformed org_repo segment %q in URL: %s", orgRepo, url)
+	}
+
+	prNumber, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid PR number %q in URL: %s", parts[1], url)
+	}
+
+	return &ProwJobPR{
+		Org:      orgRepo[:sepIdx],
+		Repo:     orgRepo[sepIdx+1:],
+		PRNumber: prNumber,
+	}, nil
+}
+
+type ghPRFile struct {
+	Filename string `json:"filename"`
+}
+
+func FetchPRChangedFiles(org, repo string, prNumber int) ([]string, error) {
+	var allFiles []string
+	page := 1
+
+	for {
+		url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=100&page=%d",
+			githubAPIBaseURL, org, repo, prNumber, page)
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch PR files: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("GitHub API returned status %d for %s", resp.StatusCode, url)
+		}
+
+		var files []ghPRFile
+		if err := json.NewDecoder(resp.Body).Decode(&files); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("failed to decode GitHub API response: %w", err)
+		}
+		resp.Body.Close()
+
+		for _, f := range files {
+			allFiles = append(allFiles, f.Filename)
+		}
+
+		if len(files) < 100 {
+			break
+		}
+		page++
+	}
+
+	return allFiles, nil
+}
+
+var sigLabelRegex = regexp.MustCompile(`\[sig-([a-zA-Z0-9-]+)\]`)
+
+func ExtractSIGFromTestName(testName string) string {
+	matches := sigLabelRegex.FindStringSubmatch(testName)
+	if matches == nil {
+		return ""
+	}
+	return "sig-" + matches[1]
+}
+
+func ExtractSIGFromJobName(jobName string) string {
+	bestMatch := ""
+	for sig := range sigCodeAreas {
+		if strings.Contains(jobName, sig) && len(sig) > len(bestMatch) {
+			bestMatch = sig
+		}
+	}
+	return bestMatch
+}
+
+func CheckFileOverlap(changedFiles, prefixes []string) []string {
+	var overlap []string
+	seen := map[string]bool{}
+	for _, f := range changedFiles {
+		for _, p := range prefixes {
+			if strings.HasPrefix(f, p) || f == p {
+				if !seen[f] {
+					seen[f] = true
+					overlap = append(overlap, f)
+				}
+				break
+			}
+		}
+	}
+	return overlap
+}
+
+func ClassifyRelevance(sigOverlap, broadOverlap []string, sig string) (relevance, reason string) {
+	if sig == "" {
+		return "unknown", "no SIG label found in test name or job name"
+	}
+	if _, ok := sigCodeAreas[sig]; !ok {
+		return "unknown", fmt.Sprintf("SIG %q not in code area mapping", sig)
+	}
+	if len(sigOverlap) > 0 {
+		return "related", fmt.Sprintf("PR changes %d file(s) in %s code areas", len(sigOverlap), sig)
+	}
+	if len(broadOverlap) > 0 {
+		return "possibly-related", fmt.Sprintf("PR changes %d file(s) in broad-impact areas (API, shared utils, test framework)", len(broadOverlap))
+	}
+	return "unrelated", fmt.Sprintf("PR changes do not overlap with %s code areas", sig)
+}
+
+func AnalyzeChangeRelevance(prowJobURL string) (*ChangeRelevanceResult, error) {
+	prowJobURL = normalizeJobURL(prowJobURL)
+
+	prInfo, err := ParseProwJobPR(prowJobURL)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("PR: %s/%s#%d", prInfo.Org, prInfo.Repo, prInfo.PRNumber)
+
+	jobBuildErrors, err := AnalyzeBuild(prowJobURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to analyze build: %w", err)
+	}
+
+	failedTests := extractFailedTestNames(jobBuildErrors)
+	if len(failedTests) == 0 {
+		return nil, fmt.Errorf("no failed tests found in build log")
+	}
+
+	log.Infof("found %d failed test(s) in build log", len(failedTests))
+
+	changedFiles, err := FetchPRChangedFiles(prInfo.Org, prInfo.Repo, prInfo.PRNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch PR changed files: %w", err)
+	}
+
+	log.Infof("PR has %d changed file(s)", len(changedFiles))
+
+	var entries []ChangeRelevanceEntry
+	var summary RelevanceSummary
+
+	for _, testName := range failedTests {
+		sig := ExtractSIGFromTestName(testName)
+		if sig == "" {
+			sig = ExtractSIGFromJobName(jobBuildErrors.JobName)
+		}
+
+		var codeAreas []string
+		if areas, ok := sigCodeAreas[sig]; ok {
+			codeAreas = areas
+		}
+
+		sigOverlap := CheckFileOverlap(changedFiles, codeAreas)
+		broadOverlap := CheckFileOverlap(changedFiles, broadChangeAreas)
+		relevance, reason := ClassifyRelevance(sigOverlap, broadOverlap, sig)
+
+		entry := ChangeRelevanceEntry{
+			TestName:  testName,
+			SIG:       sig,
+			CodeAreas: codeAreas,
+			Relevance: relevance,
+			Reason:    reason,
+		}
+		if len(sigOverlap) > 0 {
+			entry.OverlapFiles = sigOverlap
+		} else if len(broadOverlap) > 0 {
+			entry.OverlapFiles = broadOverlap
+		}
+
+		entries = append(entries, entry)
+
+		summary.TotalFailedTests++
+		switch relevance {
+		case "related":
+			summary.Related++
+		case "possibly-related":
+			summary.PossiblyRelated++
+		case "unrelated":
+			summary.Unrelated++
+		case "unknown":
+			summary.Unknown++
+		}
+	}
+
+	return &ChangeRelevanceResult{
+		ProwJobURL:   prowJobURL,
+		JobName:      jobBuildErrors.JobName,
+		Org:          prInfo.Org,
+		Repo:         prInfo.Repo,
+		PRNumber:     prInfo.PRNumber,
+		ChangedFiles: changedFiles,
+		FailedTests:  entries,
+		Summary:      summary,
+	}, nil
+}
+
+func WriteChangeRelevanceResultYAML(outputPath string, result *ChangeRelevanceResult) error {
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
+	}
+	defer outputFile.Close()
+
+	encoder := yaml.NewEncoder(outputFile)
+	if err := encoder.Encode(result); err != nil {
+		return fmt.Errorf("failed to encode YAML: %v", err)
+	}
+	return nil
+}

--- a/pkg/ci-failures/change_relevance.go
+++ b/pkg/ci-failures/change_relevance.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -111,28 +113,28 @@ var broadChangeAreas = []string{
 const prowPRLogsMarker = "/pr-logs/pull/"
 
 func ParseProwJobPR(prowJobURL string) (*ProwJobPR, error) {
-	url := normalizeJobURL(prowJobURL)
+	jobURL := normalizeJobURL(prowJobURL)
 
-	idx := strings.Index(url, prowPRLogsMarker)
+	idx := strings.Index(jobURL, prowPRLogsMarker)
 	if idx < 0 {
-		return nil, fmt.Errorf("URL is not a PR build (no pr-logs/pull/ segment): %s", url)
+		return nil, fmt.Errorf("URL is not a PR build (no pr-logs/pull/ segment): %s", jobURL)
 	}
 
-	remainder := url[idx+len(prowPRLogsMarker):]
+	remainder := jobURL[idx+len(prowPRLogsMarker):]
 	parts := strings.Split(remainder, "/")
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("malformed Prow PR URL, expected {org}_{repo}/{pr}/...: %s", url)
+		return nil, fmt.Errorf("malformed Prow PR URL, expected {org}_{repo}/{pr}/...: %s", jobURL)
 	}
 
 	orgRepo := parts[0]
 	sepIdx := strings.Index(orgRepo, "_")
 	if sepIdx < 1 || sepIdx >= len(orgRepo)-1 {
-		return nil, fmt.Errorf("malformed org_repo segment %q in URL: %s", orgRepo, url)
+		return nil, fmt.Errorf("malformed org_repo segment %q in URL: %s", orgRepo, jobURL)
 	}
 
 	prNumber, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid PR number %q in URL: %s", parts[1], url)
+		return nil, fmt.Errorf("invalid PR number %q in URL: %s", parts[1], jobURL)
 	}
 
 	return &ProwJobPR{
@@ -149,12 +151,16 @@ type ghPRFile struct {
 func FetchPRChangedFiles(org, repo string, prNumber int) ([]string, error) {
 	var allFiles []string
 	page := 1
+	client := &http.Client{Timeout: 30 * time.Second}
 
 	for {
-		url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=100&page=%d",
-			githubAPIBaseURL, org, repo, prNumber, page)
+		params := url.Values{}
+		params.Set("per_page", "100")
+		params.Set("page", strconv.Itoa(page))
+		apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?%s",
+			githubAPIBaseURL, org, repo, prNumber, params.Encode())
 
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		req, err := http.NewRequest(http.MethodGet, apiURL, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
@@ -164,14 +170,14 @@ func FetchPRChangedFiles(org, repo string, prNumber int) ([]string, error) {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch PR files: %w", err)
 		}
 
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
-			return nil, fmt.Errorf("GitHub API returned status %d for %s", resp.StatusCode, url)
+			return nil, fmt.Errorf("GitHub API returned status %d for %s", resp.StatusCode, apiURL)
 		}
 
 		var files []ghPRFile
@@ -279,6 +285,7 @@ func AnalyzeChangeRelevance(prowJobURL string) (*ChangeRelevanceResult, error) {
 	var entries []ChangeRelevanceEntry
 	var summary RelevanceSummary
 
+	broadOverlap := CheckFileOverlap(changedFiles, broadChangeAreas)
 	for _, testName := range failedTests {
 		sig := ExtractSIGFromTestName(testName)
 		if sig == "" {
@@ -291,7 +298,6 @@ func AnalyzeChangeRelevance(prowJobURL string) (*ChangeRelevanceResult, error) {
 		}
 
 		sigOverlap := CheckFileOverlap(changedFiles, codeAreas)
-		broadOverlap := CheckFileOverlap(changedFiles, broadChangeAreas)
 		relevance, reason := ClassifyRelevance(sigOverlap, broadOverlap, sig)
 
 		entry := ChangeRelevanceEntry{

--- a/pkg/ci-failures/change_relevance_test.go
+++ b/pkg/ci-failures/change_relevance_test.go
@@ -1,0 +1,303 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseProwJobPR(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOrg   string
+		wantRepo  string
+		wantPR    int
+		wantError bool
+	}{
+		{
+			name:     "standard PR URL",
+			url:      "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17760/pull-kubevirt-e2e-k8s-1.35-sig-compute/2053843644594524160",
+			wantOrg:  "kubevirt",
+			wantRepo: "kubevirt",
+			wantPR:   17760,
+		},
+		{
+			name:     "repo with hyphens",
+			url:      "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/456/some-job/123456",
+			wantOrg:  "kubevirt",
+			wantRepo: "containerized-data-importer",
+			wantPR:   456,
+		},
+		{
+			name:     "double-slash URL normalized",
+			url:      "https://prow.ci.kubevirt.io//view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/100/job/999",
+			wantOrg:  "kubevirt",
+			wantRepo: "kubevirt",
+			wantPR:   100,
+		},
+		{
+			name:      "periodic build",
+			url:       "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.35-sig-compute/2053843644594524160",
+			wantError: true,
+		},
+		{
+			name:      "malformed org_repo",
+			url:       "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/badformat/17760/job/123",
+			wantError: true,
+		},
+		{
+			name:      "non-numeric PR number",
+			url:       "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/abc/job/123",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseProwJobPR(tt.url)
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Org != tt.wantOrg {
+				t.Errorf("Org = %q, want %q", result.Org, tt.wantOrg)
+			}
+			if result.Repo != tt.wantRepo {
+				t.Errorf("Repo = %q, want %q", result.Repo, tt.wantRepo)
+			}
+			if result.PRNumber != tt.wantPR {
+				t.Errorf("PRNumber = %d, want %d", result.PRNumber, tt.wantPR)
+			}
+		})
+	}
+}
+
+func TestExtractSIGFromTestName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"sig-compute", "[sig-compute] Live Migrations with a strategy set", "sig-compute"},
+		{"sig-network", "[sig-network] VMI connectivity should allow traffic", "sig-network"},
+		{"sig-compute-migrations", "[sig-compute-migrations] Live Migration tests", "sig-compute-migrations"},
+		{"sig-storage", "[sig-storage] DataVolume tests", "sig-storage"},
+		{"no SIG label", "some test without sig label", ""},
+		{"first SIG wins", "[sig-compute] test [sig-network] cross-sig", "sig-compute"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractSIGFromTestName(tt.input)
+			if got != tt.expected {
+				t.Errorf("ExtractSIGFromTestName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractSIGFromJobName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"sig-compute job", "pull-kubevirt-e2e-k8s-1.35-sig-compute", "sig-compute"},
+		{"sig-network job", "pull-kubevirt-e2e-k8s-1.35-sig-network", "sig-network"},
+		{"sig-compute-migrations job", "pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations", "sig-compute-migrations"},
+		{"no SIG in job name", "pull-kubevirt-unit-test", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractSIGFromJobName(tt.input)
+			if got != tt.expected {
+				t.Errorf("ExtractSIGFromJobName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckFileOverlap(t *testing.T) {
+	tests := []struct {
+		name         string
+		changedFiles []string
+		prefixes     []string
+		wantCount    int
+	}{
+		{
+			name:         "direct match",
+			changedFiles: []string{"pkg/virt-handler/vm.go", "pkg/network/pod.go"},
+			prefixes:     []string{"pkg/virt-handler/"},
+			wantCount:    1,
+		},
+		{
+			name:         "no overlap",
+			changedFiles: []string{"pkg/network/pod.go", "tests/network/vmi_test.go"},
+			prefixes:     []string{"pkg/virt-handler/", "pkg/storage/"},
+			wantCount:    0,
+		},
+		{
+			name:         "multiple matches",
+			changedFiles: []string{"pkg/virt-handler/vm.go", "pkg/virt-launcher/cmd.go", "README.md"},
+			prefixes:     []string{"pkg/virt-handler/", "pkg/virt-launcher/"},
+			wantCount:    2,
+		},
+		{
+			name:         "exact file match",
+			changedFiles: []string{"go.mod", "go.sum", "pkg/foo/bar.go"},
+			prefixes:     []string{"go.mod", "go.sum"},
+			wantCount:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckFileOverlap(tt.changedFiles, tt.prefixes)
+			if len(got) != tt.wantCount {
+				t.Errorf("CheckFileOverlap() returned %d files, want %d: %v", len(got), tt.wantCount, got)
+			}
+		})
+	}
+}
+
+func TestClassifyRelevance(t *testing.T) {
+	tests := []struct {
+		name          string
+		sigOverlap    []string
+		broadOverlap  []string
+		sig           string
+		wantRelevance string
+	}{
+		{
+			name:          "related - direct overlap",
+			sigOverlap:    []string{"pkg/virt-handler/vm.go"},
+			broadOverlap:  nil,
+			sig:           "sig-compute",
+			wantRelevance: "related",
+		},
+		{
+			name:          "possibly-related - broad overlap only",
+			sigOverlap:    nil,
+			broadOverlap:  []string{"staging/src/kubevirt.io/api/core/types.go"},
+			sig:           "sig-compute",
+			wantRelevance: "possibly-related",
+		},
+		{
+			name:          "unrelated - no overlap",
+			sigOverlap:    nil,
+			broadOverlap:  nil,
+			sig:           "sig-compute",
+			wantRelevance: "unrelated",
+		},
+		{
+			name:          "unknown - no SIG",
+			sigOverlap:    nil,
+			broadOverlap:  nil,
+			sig:           "",
+			wantRelevance: "unknown",
+		},
+		{
+			name:          "unknown - unmapped SIG",
+			sigOverlap:    nil,
+			broadOverlap:  nil,
+			sig:           "sig-unknown-new",
+			wantRelevance: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relevance, _ := ClassifyRelevance(tt.sigOverlap, tt.broadOverlap, tt.sig)
+			if relevance != tt.wantRelevance {
+				t.Errorf("ClassifyRelevance() = %q, want %q", relevance, tt.wantRelevance)
+			}
+		})
+	}
+}
+
+func TestFetchPRChangedFiles(t *testing.T) {
+	files := []ghPRFile{
+		{Filename: "pkg/virt-handler/vm.go"},
+		{Filename: "pkg/virt-handler/vm_test.go"},
+		{Filename: "tests/compute/vmi_lifecycle_test.go"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expected := "/repos/kubevirt/kubevirt/pulls/100/files"
+		if r.URL.Path != expected {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(files)
+	}))
+	defer server.Close()
+
+	origBase := githubAPIBaseURL
+	defer func() { githubAPIBaseURL = origBase }()
+	githubAPIBaseURL = server.URL
+
+	result, err := FetchPRChangedFiles("kubevirt", "kubevirt", 100)
+	if err != nil {
+		t.Fatalf("FetchPRChangedFiles() error: %v", err)
+	}
+	if len(result) != 3 {
+		t.Errorf("got %d files, want 3", len(result))
+	}
+}
+
+func TestFetchPRChangedFilesPagination(t *testing.T) {
+	page1 := make([]ghPRFile, 100)
+	for i := range page1 {
+		page1[i] = ghPRFile{Filename: fmt.Sprintf("file%d.go", i)}
+	}
+	page2 := []ghPRFile{{Filename: "last.go"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		if page == "2" {
+			json.NewEncoder(w).Encode(page2)
+		} else {
+			json.NewEncoder(w).Encode(page1)
+		}
+	}))
+	defer server.Close()
+
+	origBase := githubAPIBaseURL
+	defer func() { githubAPIBaseURL = origBase }()
+	githubAPIBaseURL = server.URL
+
+	result, err := FetchPRChangedFiles("kubevirt", "kubevirt", 100)
+	if err != nil {
+		t.Fatalf("FetchPRChangedFiles() error: %v", err)
+	}
+	if len(result) != 101 {
+		t.Errorf("got %d files, want 101", len(result))
+	}
+}
+
+func TestFetchPRChangedFilesNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	origBase := githubAPIBaseURL
+	defer func() { githubAPIBaseURL = origBase }()
+	githubAPIBaseURL = server.URL
+
+	_, err := FetchPRChangedFiles("kubevirt", "kubevirt", 999)
+	if err == nil {
+		t.Error("expected error for 404, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `change-relevance` subcommand that checks whether a PR's changed files overlap with the code areas of failing tests in a Prow build
- Parses org/repo/PR from Prow job URL, fetches changed files via GitHub REST API, maps failed tests to SIG code areas, and classifies relevance as related/possibly-related/unrelated/unknown
- Includes Claude Code skill definition for interactive use

## Test plan

- [x] Unit tests for URL parsing, SIG extraction, file overlap, relevance classification, and GitHub API pagination
- [x] `go build ./cmd/ci-failures` passes
- [x] `go test ./pkg/ci-failures/... -run TestParseProwJobPR` passes
- [x] `go test ./pkg/ci-failures/... -run TestExtractSIG` passes
- [x] `go test ./pkg/ci-failures/... -run TestCheckFileOverlap` passes
- [x] `go test ./pkg/ci-failures/... -run TestClassifyRelevance` passes
- [x] `go test ./pkg/ci-failures/... -run TestFetchPRChangedFiles` passes
- [ ] Manual: `go run ./cmd/ci-failures change-relevance <prow-pr-build-url>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)