### PR TITLE
feat: add per-session output isolation for concurrent agent sessions

### DIFF
--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -19,10 +19,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	tmpOutputPath = "output/tmp"
-	mdOutputPath  = "output/kubevirt/kubevirt/ci-failures"
-)
+var tmpOutputPath = "output/tmp"
+
+const mdOutputPath = "output/kubevirt/kubevirt/ci-failures"
+
+var sessionID string
 
 var (
 	//go:embed ci-failures.gomd
@@ -33,6 +34,15 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "ci-failures",
 		Short: "A CLI tool to process CI failures.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if sessionID == "" {
+				sessionID = os.Getenv("CLAUDE_CODE_SESSION_ID")
+			}
+			if sessionID != "" {
+				tmpOutputPath = filepath.Join("output/tmp/sessions", sessionID)
+			}
+			return nil
+		},
 	}
 
 	generateCmd = &cobra.Command{
@@ -160,7 +170,7 @@ func generateYAML(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed downloading build logs: %v", err)
 	}
-	_, err = cifailures.ExtractErrors(ciFailureJobURLs)
+	_, err = cifailures.ExtractErrors(ciFailureJobURLs, tmpOutputPath)
 	if err != nil {
 		return fmt.Errorf("failed extracting errors from build logs: %v", err)
 	}
@@ -417,6 +427,9 @@ func changeRelevance(_ *cobra.Command, args []string) error {
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
+
+	rootCmd.PersistentFlags().StringVar(&sessionID, "session-id", "",
+		"Isolate analysis output in a per-session directory; defaults to CLAUDE_CODE_SESSION_ID env var if set")
 
 	testRateCmd.Flags().IntVar(&testRateDays, "days", 7, "Number of days to cover (max 28, fetches multiple weekly reports)")
 

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -39,7 +39,12 @@ var (
 				sessionID = os.Getenv("CLAUDE_CODE_SESSION_ID")
 			}
 			if sessionID != "" {
+				if strings.Contains(sessionID, "..") || strings.Contains(sessionID, "/") || strings.Contains(sessionID, "\\") {
+					return fmt.Errorf("invalid session ID: %s", sessionID)
+				}
 				tmpOutputPath = filepath.Join("output/tmp/sessions", sessionID)
+			} else {
+				tmpOutputPath = "output/tmp"
 			}
 			return nil
 		},

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -143,7 +143,7 @@ func SIGForGroup(whatever string) string {
 // ExtractErrors fetches failures from the build logs of build urls given through the file.
 // It writes matching lines into one file per group, under the provided output directory.
 // It returns the file names of the files created.
-func ExtractErrors(ciFailureJobURLs []string) ([]string, error) {
+func ExtractErrors(ciFailureJobURLs []string, outputDir string) ([]string, error) {
 	var outputFiles []string
 
 	urlsNotMatchedByGroup := make(map[string]struct{})
@@ -230,7 +230,7 @@ func ExtractErrors(ciFailureJobURLs []string) ([]string, error) {
 			continue
 		}
 
-		outputDirName := fmt.Sprintf("output/tmp/errors-%s", sigName)
+		outputDirName := filepath.Join(outputDir, fmt.Sprintf("errors-%s", sigName))
 		if err := os.MkdirAll(outputDirName, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create output directory: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Adds `--session-id` flag (with `CLAUDE_CODE_SESSION_ID` env var fallback) to the `ci-failures` CLI
- When set, redirects analysis output to `output/tmp/sessions/<id>/` so parallel agent sessions don't overwrite each other's results
- Shared caches (`build-logs/`, `k8s-artifacts/`) keyed by build ID remain at their fixed paths — no duplication
- `mdOutputPath` is unchanged — `generate md` in GitHub Actions continues to write to the same stable path

## Test plan

- [ ] `ci-failures analyze-build <url>` without `--session-id` writes to `output/tmp/` (unchanged behavior)
- [ ] `ci-failures --session-id test1 analyze-build <url>` writes to `output/tmp/sessions/test1/`
- [ ] `CLAUDE_CODE_SESSION_ID=test2 ci-failures analyze-build <url>` writes to `output/tmp/sessions/test2/`
- [ ] Flag overrides env var: `CLAUDE_CODE_SESSION_ID=test2 ci-failures --session-id test1 ...` → `output/tmp/sessions/test1/`
- [ ] Shared caches (`build-logs/`, `k8s-artifacts/`) are not duplicated per session
- [ ] `go build ./cmd/ci-failures/` passes
- [ ] `go test ./pkg/ci-failures/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)