### PR TITLE
Add per-k8s-version and per-lane flakiness breakdown to test-rate

### DIFF
--- a/.claude/skills/test-failure-rate/SKILL.md
+++ b/.claude/skills/test-failure-rate/SKILL.md
@@ -51,6 +51,16 @@ After data generation:
      - `total_skipped`: total skips
      - `success_rate`: percentage (0-100)
      - `severity`: classification of the failure
+     - `k8s_versions`: per-Kubernetes-version breakdown, sorted by success rate ascending (worst first), each with:
+       - `version`: Kubernetes version (e.g., "1.35", "1.36", or "unknown")
+       - `succeeded`, `failed`, `skipped`: counts aggregated across all lanes for this version
+       - `success_rate`: percentage (0-100)
+       - `severity`: classification for this version
+       - `lanes`: per-lane breakdown within this version, sorted by success rate ascending, each with:
+         - `lane`: job name
+         - `succeeded`, `failed`, `skipped`: counts for this lane
+         - `success_rate`: percentage (0-100)
+         - `severity`: classification for this lane
 
 ## Severity classification
 
@@ -63,6 +73,8 @@ After data generation:
 
 For each failed test, report:
 1. The test name
-2. The success rate and total runs (succeeded + failed)
+2. The overall success rate and total runs (succeeded + failed)
 3. The severity classification
 4. If severity is "unknown", note that the test may be new or not covered by flakefinder
+5. Per-k8s-version success rates, highlighting versions where the test is notably worse
+6. Per-lane details when they reveal that specific lanes drive the flakiness

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -141,7 +141,7 @@ func SIGForGroup(whatever string) string {
 }
 
 // ExtractErrors fetches failures from the build logs of build urls given through the file.
-// It writes matching lines into one file per group, prefixed with 'output/tmp/errors-'.
+// It writes matching lines into one file per group, under the provided output directory.
 // It returns the file names of the files created.
 func ExtractErrors(ciFailureJobURLs []string) ([]string, error) {
 	var outputFiles []string

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -42,13 +43,33 @@ type TestRateResult struct {
 }
 
 type TestRateEntry struct {
-	TestName       string  `yaml:"test_name"`
-	MatchedName    string  `yaml:"matched_name,omitempty"`
-	TotalSucceeded int     `yaml:"total_succeeded"`
-	TotalFailed    int     `yaml:"total_failed"`
-	TotalSkipped   int     `yaml:"total_skipped"`
-	SuccessRate    float64 `yaml:"success_rate"`
-	Severity       string  `yaml:"severity"`
+	TestName       string           `yaml:"test_name"`
+	MatchedName    string           `yaml:"matched_name,omitempty"`
+	TotalSucceeded int              `yaml:"total_succeeded"`
+	TotalFailed    int              `yaml:"total_failed"`
+	TotalSkipped   int              `yaml:"total_skipped"`
+	SuccessRate    float64          `yaml:"success_rate"`
+	Severity       string           `yaml:"severity"`
+	K8sVersions    []K8sVersionRate `yaml:"k8s_versions,omitempty"`
+}
+
+type K8sVersionRate struct {
+	Version     string     `yaml:"version"`
+	Succeeded   int        `yaml:"succeeded"`
+	Failed      int        `yaml:"failed"`
+	Skipped     int        `yaml:"skipped"`
+	SuccessRate float64    `yaml:"success_rate"`
+	Severity    string     `yaml:"severity"`
+	Lanes       []LaneRate `yaml:"lanes"`
+}
+
+type LaneRate struct {
+	Lane        string  `yaml:"lane"`
+	Succeeded   int     `yaml:"succeeded"`
+	Failed      int     `yaml:"failed"`
+	Skipped     int     `yaml:"skipped"`
+	SuccessRate float64 `yaml:"success_rate"`
+	Severity    string  `yaml:"severity"`
 }
 
 func AnalyzeTestRate(prowJobURL string, days int) (*TestRateResult, error) {
@@ -293,27 +314,83 @@ func computeTestRate(testName string, report *FlakefinderReport) TestRateEntry {
 		return entry
 	}
 
-	for _, details := range jobData {
+	versionLanes := map[string][]LaneRate{}
+	for laneName, details := range jobData {
 		entry.TotalSucceeded += details.Succeeded
 		entry.TotalFailed += details.Failed
 		entry.TotalSkipped += details.Skipped
+
+		lane := LaneRate{
+			Lane:      laneName,
+			Succeeded: details.Succeeded,
+			Failed:    details.Failed,
+			Skipped:   details.Skipped,
+		}
+		laneTotal := details.Succeeded + details.Failed
+		if laneTotal > 0 {
+			lane.SuccessRate = float64(details.Succeeded) / float64(laneTotal) * 100.0
+		}
+		lane.Severity = classifySeverity(lane.SuccessRate, laneTotal)
+
+		version := extractK8sVersion(laneName)
+		versionLanes[version] = append(versionLanes[version], lane)
 	}
+
+	for version, lanes := range versionLanes {
+		sort.Slice(lanes, func(i, j int) bool {
+			return lanes[i].SuccessRate < lanes[j].SuccessRate
+		})
+		vr := K8sVersionRate{
+			Version: version,
+			Lanes:   lanes,
+		}
+		for _, l := range lanes {
+			vr.Succeeded += l.Succeeded
+			vr.Failed += l.Failed
+			vr.Skipped += l.Skipped
+		}
+		vrTotal := vr.Succeeded + vr.Failed
+		if vrTotal > 0 {
+			vr.SuccessRate = float64(vr.Succeeded) / float64(vrTotal) * 100.0
+		}
+		vr.Severity = classifySeverity(vr.SuccessRate, vrTotal)
+		entry.K8sVersions = append(entry.K8sVersions, vr)
+	}
+
+	sort.Slice(entry.K8sVersions, func(i, j int) bool {
+		return entry.K8sVersions[i].SuccessRate < entry.K8sVersions[j].SuccessRate
+	})
 
 	total := entry.TotalSucceeded + entry.TotalFailed
 	if total > 0 {
 		entry.SuccessRate = float64(entry.TotalSucceeded) / float64(total) * 100.0
 	}
 
-	switch {
-	case entry.SuccessRate >= 95:
-		entry.Severity = "likely-pr-related"
-	case entry.SuccessRate >= 80:
-		entry.Severity = "inconclusive"
-	default:
-		entry.Severity = "likely-flaky"
-	}
+	entry.Severity = classifySeverity(entry.SuccessRate, total)
 
 	return entry
+}
+
+func extractK8sVersion(laneName string) string {
+	m := k8sVersionRegex.FindStringSubmatch(laneName)
+	if len(m) < 2 {
+		return "unknown"
+	}
+	return m[1]
+}
+
+func classifySeverity(successRate float64, total int) string {
+	if total == 0 {
+		return "unknown"
+	}
+	switch {
+	case successRate >= 95:
+		return "likely-pr-related"
+	case successRate >= 80:
+		return "inconclusive"
+	default:
+		return "likely-flaky"
+	}
 }
 
 func WriteTestRateResultYAML(outputPath string, result *TestRateResult) error {

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -338,7 +338,10 @@ func computeTestRate(testName string, report *FlakefinderReport) TestRateEntry {
 
 	for version, lanes := range versionLanes {
 		sort.Slice(lanes, func(i, j int) bool {
-			return lanes[i].SuccessRate < lanes[j].SuccessRate
+			if lanes[i].SuccessRate != lanes[j].SuccessRate {
+				return lanes[i].SuccessRate < lanes[j].SuccessRate
+			}
+			return lanes[i].Lane < lanes[j].Lane
 		})
 		vr := K8sVersionRate{
 			Version: version,
@@ -358,7 +361,10 @@ func computeTestRate(testName string, report *FlakefinderReport) TestRateEntry {
 	}
 
 	sort.Slice(entry.K8sVersions, func(i, j int) bool {
-		return entry.K8sVersions[i].SuccessRate < entry.K8sVersions[j].SuccessRate
+		if entry.K8sVersions[i].SuccessRate != entry.K8sVersions[j].SuccessRate {
+			return entry.K8sVersions[i].SuccessRate < entry.K8sVersions[j].SuccessRate
+		}
+		return entry.K8sVersions[i].Version < entry.K8sVersions[j].Version
 	})
 
 	total := entry.TotalSucceeded + entry.TotalFailed

--- a/pkg/ci-failures/test_rate_test.go
+++ b/pkg/ci-failures/test_rate_test.go
@@ -120,30 +120,82 @@ func TestComputeTestRate(t *testing.T) {
 		},
 		Data: map[string]map[string]*TestDetails{
 			"[sig-compute] Live Migrations with a strategy set": {
-				"job-a": {Succeeded: 80, Failed: 10, Skipped: 5},
-				"job-b": {Succeeded: 70, Failed: 20, Skipped: 3},
+				"pull-kubevirt-e2e-k8s-1.35-sig-compute":   {Succeeded: 80, Failed: 10, Skipped: 5},
+				"pull-kubevirt-e2e-k8s-1.36-sig-compute":   {Succeeded: 70, Failed: 20, Skipped: 3},
+				"pull-kubevirt-e2e-kind-1.35-sig-compute":  {Succeeded: 50, Failed: 5, Skipped: 1},
 			},
 		},
 	}
 
 	entry := computeTestRate("[sig-compute] Live Migrations with a strategy set", report)
 
-	if entry.TotalSucceeded != 150 {
-		t.Errorf("TotalSucceeded = %d, want 150", entry.TotalSucceeded)
+	if entry.TotalSucceeded != 200 {
+		t.Errorf("TotalSucceeded = %d, want 200", entry.TotalSucceeded)
 	}
-	if entry.TotalFailed != 30 {
-		t.Errorf("TotalFailed = %d, want 30", entry.TotalFailed)
+	if entry.TotalFailed != 35 {
+		t.Errorf("TotalFailed = %d, want 35", entry.TotalFailed)
 	}
-	if entry.TotalSkipped != 8 {
-		t.Errorf("TotalSkipped = %d, want 8", entry.TotalSkipped)
+	if entry.TotalSkipped != 9 {
+		t.Errorf("TotalSkipped = %d, want 9", entry.TotalSkipped)
 	}
 
-	expectedRate := float64(150) / float64(180) * 100.0
+	expectedRate := float64(200) / float64(235) * 100.0
 	if entry.SuccessRate != expectedRate {
 		t.Errorf("SuccessRate = %f, want %f", entry.SuccessRate, expectedRate)
 	}
 	if entry.Severity != "inconclusive" {
 		t.Errorf("Severity = %q, want %q", entry.Severity, "inconclusive")
+	}
+
+	// Two k8s versions: 1.35 (two lanes aggregated) and 1.36 (one lane)
+	if len(entry.K8sVersions) != 2 {
+		t.Fatalf("len(K8sVersions) = %d, want 2", len(entry.K8sVersions))
+	}
+	// Sorted by success rate ascending: 1.36 (77.8%) before 1.35 (89.7%)
+	if entry.K8sVersions[0].Version != "1.36" {
+		t.Errorf("K8sVersions[0].Version = %q, want %q", entry.K8sVersions[0].Version, "1.36")
+	}
+	if entry.K8sVersions[0].Succeeded != 70 || entry.K8sVersions[0].Failed != 20 {
+		t.Errorf("K8sVersions[0] = %d/%d, want 70/20", entry.K8sVersions[0].Succeeded, entry.K8sVersions[0].Failed)
+	}
+	if entry.K8sVersions[0].Severity != "likely-flaky" {
+		t.Errorf("K8sVersions[0].Severity = %q, want %q", entry.K8sVersions[0].Severity, "likely-flaky")
+	}
+	if len(entry.K8sVersions[0].Lanes) != 1 {
+		t.Fatalf("K8sVersions[0] lane count = %d, want 1", len(entry.K8sVersions[0].Lanes))
+	}
+
+	if entry.K8sVersions[1].Version != "1.35" {
+		t.Errorf("K8sVersions[1].Version = %q, want %q", entry.K8sVersions[1].Version, "1.35")
+	}
+	// 1.35 aggregates k8s-1.35 (80/10) + kind-1.35 (50/5) = 130/15
+	if entry.K8sVersions[1].Succeeded != 130 || entry.K8sVersions[1].Failed != 15 {
+		t.Errorf("K8sVersions[1] = %d/%d, want 130/15", entry.K8sVersions[1].Succeeded, entry.K8sVersions[1].Failed)
+	}
+	if len(entry.K8sVersions[1].Lanes) != 2 {
+		t.Fatalf("K8sVersions[1] lane count = %d, want 2", len(entry.K8sVersions[1].Lanes))
+	}
+}
+
+func TestExtractK8sVersion(t *testing.T) {
+	tests := []struct {
+		lane    string
+		version string
+	}{
+		{"pull-kubevirt-e2e-k8s-1.35-sig-compute", "1.35"},
+		{"periodic-kubevirt-e2e-k8s-1.36-sig-network", "1.36"},
+		{"periodic-kubevirt-e2e-kind-1.34-sev", "1.34"},
+		{"pull-kubevirt-e2e-kind-1.35-sig-compute-arm64", "1.35"},
+		{"periodic-kubevirt-e2e-test-S390X", "unknown"},
+		{"some-job-without-version", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.lane, func(t *testing.T) {
+			got := extractK8sVersion(tt.lane)
+			if got != tt.version {
+				t.Errorf("extractK8sVersion(%q) = %q, want %q", tt.lane, got, tt.version)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a two-level hierarchy to the test-rate YAML output: per-Kubernetes-version, then per-lane within each version
- Extracts k8s version from lane names (e.g., `pull-kubevirt-e2e-k8s-1.35-sig-compute` → `1.35`) using the existing `k8sVersionRegex`
- Sorts both levels by success rate ascending (worst first) so the most problematic versions and lanes surface immediately
- Extracts `classifySeverity` helper to avoid duplicating threshold logic

## Test plan
- [x] `TestExtractK8sVersion` covers `k8s-*`, `kind-*`, and versionless lane names
- [x] `TestComputeTestRate` verifies version grouping, aggregation, and sort order with realistic multi-version lane names
- [x] Existing severity bucket and merge tests pass unchanged
- [ ] Manual: `go run ./cmd/ci-failures test-rate --days 28 <prow-job-url>` and inspect YAML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)