### PR TITLE
feat: add lane-rate subcommand for testgrid lane failure analysis

### DIFF
--- a/.claude/skills/lane-failure-rate/SKILL.md
+++ b/.claude/skills/lane-failure-rate/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: lane-failure-rate
+description: >
+    Show failure rates for all tests in a testgrid lane over the last N days.
+    Use when the user provides a testgrid URL and wants to see which tests are failing in that lane.
+allowed-tools: [Read, Glob, Bash(go run:*)]
+---
+
+## Overview
+
+This skill analyzes a testgrid lane and calculates failure rates for every test that has at least one failure in the requested time window. Unlike test-failure-rate (which starts from a single build's failed tests and looks them up in flakefinder), this skill operates at the lane level — it fetches all test results directly from testgrid and computes rates from raw pass/fail data.
+
+## Data generation
+
+Run the `lane-rate` subcommand with a testgrid URL:
+
+```bash
+$ go run ./cmd/ci-failures lane-rate <testgrid-url>
+```
+
+To control the analysis window (default 14 days):
+
+```bash
+$ go run ./cmd/ci-failures lane-rate --days 21 <testgrid-url>
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures lane-rate --days 14 "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage"
+```
+
+This produces `output/tmp/lane-rate-{tab-name}.yaml`.
+
+## Analysis
+
+After data generation:
+
+1. Use Glob to find the `output/tmp/lane-rate-*.yaml` file
+2. Read the YAML. The structure is:
+   - `testgrid_url`: the original testgrid URL analyzed
+   - `dashboard`: the testgrid dashboard name (e.g., "kubevirt-periodics")
+   - `tab`: the testgrid tab/lane name (e.g., "periodic-kubevirt-e2e-k8s-1.36-sig-storage")
+   - `report_days`: number of days covered
+   - `report_period_start`: start of the analysis window (ISO 8601)
+   - `report_period_end`: end of the analysis window (ISO 8601)
+   - `total_builds`: number of builds in the analysis window
+   - `failed_tests`: list of tests with at least one failure, sorted by success rate ascending (worst first), each with:
+     - `test_name`: full test name from testgrid
+     - `succeeded`: number of passing runs
+     - `failed`: number of failing runs (includes flaky runs)
+     - `skipped`: number of skipped/not-run entries
+     - `total_runs`: succeeded + failed (excludes skipped)
+     - `success_rate`: percentage (0-100)
+     - `severity`: classification of the failure pattern
+     - `recent_failures`: up to 10 most recent failures, each with:
+       - `build_id`: the build/column identifier
+       - `timestamp`: ISO 8601 timestamp of the build
+       - `message`: failure message from testgrid (may be empty)
+
+## Severity classification
+
+- **likely-pr-related** (success rate >= 95%): rare failure, likely a one-off
+- **inconclusive** (success rate >= 80%): moderate failure rate, needs investigation
+- **likely-flaky** (success rate < 80%): frequent failures, likely a known flake
+- **unknown**: no pass+fail data available
+
+## Presenting results
+
+1. Lead with a summary: total builds analyzed, number of tests with failures
+2. Group tests by severity, starting with the worst (likely-flaky)
+3. For each test, report the test name, success rate, total runs, and severity
+4. For tests with low success rates, include the most recent failure messages to help diagnose the issue
+5. Note the total builds count to contextualize rates — a test that failed 1/2 is different from 1/42
+6. Tests tagged `[QUARANTINE]` are already known flakes; note this when presenting
+
+## Combining with test-failure-rate
+
+The `lane-rate` command gives a lane-wide overview, while `test-failure-rate` gives a cross-lane view for specific tests. Use `lane-rate` to find which tests are problematic in a lane, then use `test-failure-rate` on a specific build to see if those tests also fail in other lanes.

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -449,16 +449,17 @@ func laneRate(_ *cobra.Command, args []string) error {
 
 	result, err := cifailures.AnalyzeLaneRate(testgridURL, laneRateDays)
 	if err != nil {
-		return fmt.Errorf("failed to analyze lane rate: %v", err)
+		return fmt.Errorf("failed to analyze lane rate: %w", err)
 	}
 
 	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("lane-rate-%s.yaml", result.Tab))
+	safeTab := strings.ReplaceAll(result.Tab, "/", "-")
+	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("lane-rate-%s.yaml", safeTab))
 	if err = cifailures.WriteLaneRateResultYAML(outputPath, result); err != nil {
-		return fmt.Errorf("failed to write YAML output: %v", err)
+		return fmt.Errorf("failed to write YAML output: %w", err)
 	}
 
 	log.Infof("wrote lane rate analysis to %s (%d tests with failures)", outputPath, len(result.FailedTests))

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -127,6 +127,7 @@ Accepts a Prow job URL, e.g.:
 	}
 
 	testRateDays int
+	laneRateDays int
 
 	testRateCmd = &cobra.Command{
 		Use:   "test-rate [prow-job-url]",
@@ -144,6 +145,20 @@ Accepts a Prow job URL, e.g.:
   https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144`,
 		Args: cobra.ExactArgs(1),
 		RunE: testRate,
+	}
+
+	laneRateCmd = &cobra.Command{
+		Use:   "lane-rate [testgrid-url]",
+		Short: "Show failure rates for all tests in a testgrid lane.",
+		Long: `Analyze a testgrid lane and show failure rates for every test that has
+at least one failure in the last N days.
+
+Accepts a testgrid URL, e.g.:
+  https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage
+
+Use --days to control the analysis window (default 14).`,
+		Args: cobra.ExactArgs(1),
+		RunE: laneRate,
 	}
 )
 
@@ -429,6 +444,27 @@ func changeRelevance(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+func laneRate(_ *cobra.Command, args []string) error {
+	testgridURL := args[0]
+
+	result, err := cifailures.AnalyzeLaneRate(testgridURL, laneRateDays)
+	if err != nil {
+		return fmt.Errorf("failed to analyze lane rate: %v", err)
+	}
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("lane-rate-%s.yaml", result.Tab))
+	if err = cifailures.WriteLaneRateResultYAML(outputPath, result); err != nil {
+		return fmt.Errorf("failed to write YAML output: %v", err)
+	}
+
+	log.Infof("wrote lane rate analysis to %s (%d tests with failures)", outputPath, len(result.FailedTests))
+	return nil
+}
+
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
@@ -437,12 +473,14 @@ func init() {
 		"Isolate analysis output in a per-session directory; defaults to CLAUDE_CODE_SESSION_ID env var if set")
 
 	testRateCmd.Flags().IntVar(&testRateDays, "days", 7, "Number of days to cover (max 28, fetches multiple weekly reports)")
+	laneRateCmd.Flags().IntVar(&laneRateDays, "days", 14, "Number of days to analyze (default 14)")
 
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(analyzeBuildCmd)
 	rootCmd.AddCommand(analyzePRCmd)
 	rootCmd.AddCommand(analyzeK8sCmd)
 	rootCmd.AddCommand(testRateCmd)
+	rootCmd.AddCommand(laneRateCmd)
 	rootCmd.AddCommand(changeRelevanceCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)

--- a/pkg/ci-failures/lane_rate.go
+++ b/pkg/ci-failures/lane_rate.go
@@ -16,6 +16,10 @@ import (
 
 var testgridBaseURL = "https://testgrid.k8s.io"
 
+var httpClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
 type testGridTableResponse struct {
 	Timestamps []int64         `json:"timestamps"`
 	Tests      []testGridTest  `json:"tests"`
@@ -87,15 +91,20 @@ func ParseTestGridURL(rawURL string) (dashboard, tab string, err error) {
 		fragment = fragment[:idx]
 	}
 	tab = fragment
+	if tab == "" {
+		return "", "", fmt.Errorf("no tab name in URL fragment: %s", rawURL)
+	}
 
 	return dashboard, tab, nil
 }
 
 func fetchTestGridTable(dashboard, tab string) (*testGridTableResponse, error) {
-	apiURL := fmt.Sprintf("%s/%s/table?tab=%s", testgridBaseURL, dashboard, url.QueryEscape(tab))
+	params := url.Values{}
+	params.Add("tab", tab)
+	apiURL := fmt.Sprintf("%s/%s/table?%s", testgridBaseURL, dashboard, params.Encode())
 	log.Infof("fetching testgrid table from %s", apiURL)
 
-	resp, err := http.Get(apiURL)
+	resp, err := httpClient.Get(apiURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch testgrid table: %w", err)
 	}
@@ -114,7 +123,11 @@ func fetchTestGridTable(dashboard, tab string) (*testGridTableResponse, error) {
 }
 
 func expandStatuses(statuses []testGridStatus) []int {
-	var result []int
+	var total int
+	for _, s := range statuses {
+		total += s.Count
+	}
+	result := make([]int, 0, total)
 	for _, s := range statuses {
 		for range s.Count {
 			result = append(result, s.Value)
@@ -238,13 +251,13 @@ func AnalyzeLaneRate(testgridURL string, days int) (*LaneRateResult, error) {
 func WriteLaneRateResultYAML(outputPath string, result *LaneRateResult) error {
 	outputFile, err := os.Create(outputPath)
 	if err != nil {
-		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
 	}
 	defer outputFile.Close()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(result); err != nil {
-		return fmt.Errorf("failed to encode YAML: %v", err)
+		return fmt.Errorf("failed to encode YAML: %w", err)
 	}
 	return nil
 }

--- a/pkg/ci-failures/lane_rate.go
+++ b/pkg/ci-failures/lane_rate.go
@@ -1,0 +1,250 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+var testgridBaseURL = "https://testgrid.k8s.io"
+
+type testGridTableResponse struct {
+	Timestamps []int64         `json:"timestamps"`
+	Tests      []testGridTest  `json:"tests"`
+	ColumnIDs  []string        `json:"column_ids"`
+}
+
+type testGridTest struct {
+	Name     string             `json:"name"`
+	Statuses []testGridStatus   `json:"statuses"`
+	Messages []string           `json:"messages"`
+}
+
+type testGridStatus struct {
+	Count int `json:"count"`
+	Value int `json:"value"`
+}
+
+const (
+	tgStatusPass    = 1
+	tgStatusFail    = 12
+	tgStatusFlaky   = 3
+)
+
+type LaneRateResult struct {
+	TestGridURL       string              `yaml:"testgrid_url"`
+	Dashboard         string              `yaml:"dashboard"`
+	Tab               string              `yaml:"tab"`
+	ReportDays        int                 `yaml:"report_days"`
+	ReportPeriodStart string              `yaml:"report_period_start"`
+	ReportPeriodEnd   string              `yaml:"report_period_end"`
+	TotalBuilds       int                 `yaml:"total_builds"`
+	FailedTests       []LaneRateTestEntry `yaml:"failed_tests"`
+}
+
+type LaneRateTestEntry struct {
+	TestName       string            `yaml:"test_name"`
+	Succeeded      int               `yaml:"succeeded"`
+	Failed         int               `yaml:"failed"`
+	Skipped        int               `yaml:"skipped"`
+	TotalRuns      int               `yaml:"total_runs"`
+	SuccessRate    float64           `yaml:"success_rate"`
+	Severity       string            `yaml:"severity"`
+	RecentFailures []LaneRateFailure `yaml:"recent_failures,omitempty"`
+}
+
+type LaneRateFailure struct {
+	BuildID   string `yaml:"build_id"`
+	Timestamp string `yaml:"timestamp"`
+	Message   string `yaml:"message,omitempty"`
+}
+
+func ParseTestGridURL(rawURL string) (dashboard, tab string, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	dashboard = strings.Trim(u.Path, "/")
+	if dashboard == "" {
+		return "", "", fmt.Errorf("no dashboard in URL path: %s", rawURL)
+	}
+
+	fragment := u.Fragment
+	if fragment == "" {
+		return "", "", fmt.Errorf("no tab in URL fragment: %s", rawURL)
+	}
+
+	if idx := strings.Index(fragment, "&"); idx >= 0 {
+		fragment = fragment[:idx]
+	}
+	tab = fragment
+
+	return dashboard, tab, nil
+}
+
+func fetchTestGridTable(dashboard, tab string) (*testGridTableResponse, error) {
+	apiURL := fmt.Sprintf("%s/%s/table?tab=%s", testgridBaseURL, dashboard, url.QueryEscape(tab))
+	log.Infof("fetching testgrid table from %s", apiURL)
+
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch testgrid table: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("testgrid returned status %d for %s", resp.StatusCode, apiURL)
+	}
+
+	var table testGridTableResponse
+	if err := json.NewDecoder(resp.Body).Decode(&table); err != nil {
+		return nil, fmt.Errorf("failed to decode testgrid response: %w", err)
+	}
+
+	return &table, nil
+}
+
+func expandStatuses(statuses []testGridStatus) []int {
+	var result []int
+	for _, s := range statuses {
+		for range s.Count {
+			result = append(result, s.Value)
+		}
+	}
+	return result
+}
+
+func filterColumnsInRange(timestamps []int64, days int) (indices []int, periodStart, periodEnd time.Time) {
+	periodEnd = time.Now().UTC()
+	periodStart = periodEnd.AddDate(0, 0, -days)
+	cutoffMs := periodStart.UnixMilli()
+
+	for i, ts := range timestamps {
+		if ts >= cutoffMs {
+			indices = append(indices, i)
+		}
+	}
+	return indices, periodStart, periodEnd
+}
+
+func AnalyzeLaneRate(testgridURL string, days int) (*LaneRateResult, error) {
+	dashboard, tab, err := ParseTestGridURL(testgridURL)
+	if err != nil {
+		return nil, err
+	}
+
+	table, err := fetchTestGridTable(dashboard, tab)
+	if err != nil {
+		return nil, err
+	}
+
+	validIndices, periodStart, periodEnd := filterColumnsInRange(table.Timestamps, days)
+
+	log.Infof("analyzing %d builds in %d-day window (%s to %s), %d tests total",
+		len(validIndices), days,
+		periodStart.Format(time.DateOnly), periodEnd.Format(time.DateOnly),
+		len(table.Tests))
+
+	var entries []LaneRateTestEntry
+
+	for _, test := range table.Tests {
+		if strings.HasSuffix(test.Name, ".Overall") {
+			continue
+		}
+
+		flat := expandStatuses(test.Statuses)
+
+		var succeeded, failed, skipped int
+		var recentFailures []LaneRateFailure
+
+		for _, idx := range validIndices {
+			if idx >= len(flat) {
+				skipped++
+				continue
+			}
+
+			switch flat[idx] {
+			case tgStatusPass:
+				succeeded++
+			case tgStatusFail, tgStatusFlaky:
+				failed++
+				if len(recentFailures) < 10 {
+					f := LaneRateFailure{
+						Timestamp: time.UnixMilli(table.Timestamps[idx]).UTC().Format(time.RFC3339),
+					}
+					if idx < len(table.ColumnIDs) {
+						f.BuildID = strings.TrimLeft(table.ColumnIDs[idx], "")
+					}
+					if idx < len(test.Messages) && test.Messages[idx] != "" {
+						f.Message = test.Messages[idx]
+					}
+					recentFailures = append(recentFailures, f)
+				}
+			default:
+				skipped++
+			}
+		}
+
+		if failed == 0 {
+			continue
+		}
+
+		totalRuns := succeeded + failed
+		var successRate float64
+		if totalRuns > 0 {
+			successRate = float64(succeeded) / float64(totalRuns) * 100.0
+		}
+
+		entries = append(entries, LaneRateTestEntry{
+			TestName:       test.Name,
+			Succeeded:      succeeded,
+			Failed:         failed,
+			Skipped:        skipped,
+			TotalRuns:      totalRuns,
+			SuccessRate:    successRate,
+			Severity:       classifySeverity(successRate, totalRuns),
+			RecentFailures: recentFailures,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].SuccessRate != entries[j].SuccessRate {
+			return entries[i].SuccessRate < entries[j].SuccessRate
+		}
+		return entries[i].TestName < entries[j].TestName
+	})
+
+	return &LaneRateResult{
+		TestGridURL:       testgridURL,
+		Dashboard:         dashboard,
+		Tab:               tab,
+		ReportDays:        days,
+		ReportPeriodStart: periodStart.Format(time.RFC3339),
+		ReportPeriodEnd:   periodEnd.Format(time.RFC3339),
+		TotalBuilds:       len(validIndices),
+		FailedTests:       entries,
+	}, nil
+}
+
+func WriteLaneRateResultYAML(outputPath string, result *LaneRateResult) error {
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
+	}
+	defer outputFile.Close()
+
+	encoder := yaml.NewEncoder(outputFile)
+	if err := encoder.Encode(result); err != nil {
+		return fmt.Errorf("failed to encode YAML: %v", err)
+	}
+	return nil
+}

--- a/pkg/ci-failures/lane_rate_test.go
+++ b/pkg/ci-failures/lane_rate_test.go
@@ -44,6 +44,11 @@ func TestParseTestGridURL(t *testing.T) {
 			url:     "https://testgrid.k8s.io/#some-tab",
 			wantErr: true,
 		},
+		{
+			name:    "empty tab after stripping params",
+			url:     "https://testgrid.k8s.io/kubevirt-periodics#&width=20",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ci-failures/lane_rate_test.go
+++ b/pkg/ci-failures/lane_rate_test.go
@@ -1,0 +1,253 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestParseTestGridURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		dashboard string
+		tab       string
+		wantErr   bool
+	}{
+		{
+			name:      "standard URL",
+			url:       "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage",
+			dashboard: "kubevirt-periodics",
+			tab:       "periodic-kubevirt-e2e-k8s-1.36-sig-storage",
+		},
+		{
+			name:      "URL with width parameter",
+			url:       "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage&width=20",
+			dashboard: "kubevirt-periodics",
+			tab:       "periodic-kubevirt-e2e-k8s-1.36-sig-storage",
+		},
+		{
+			name:      "URL with trailing slash",
+			url:       "https://testgrid.k8s.io/kubevirt-periodics/#periodic-kubevirt-e2e-k8s-1.36-sig-storage",
+			dashboard: "kubevirt-periodics",
+			tab:       "periodic-kubevirt-e2e-k8s-1.36-sig-storage",
+		},
+		{
+			name:    "missing fragment",
+			url:     "https://testgrid.k8s.io/kubevirt-periodics",
+			wantErr: true,
+		},
+		{
+			name:    "missing path",
+			url:     "https://testgrid.k8s.io/#some-tab",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dashboard, tab, err := ParseTestGridURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dashboard != tt.dashboard {
+				t.Errorf("dashboard = %q, want %q", dashboard, tt.dashboard)
+			}
+			if tab != tt.tab {
+				t.Errorf("tab = %q, want %q", tab, tt.tab)
+			}
+		})
+	}
+}
+
+func TestExpandStatuses(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []testGridStatus
+		want     []int
+	}{
+		{
+			name:     "single entry",
+			statuses: []testGridStatus{{Count: 5, Value: 1}},
+			want:     []int{1, 1, 1, 1, 1},
+		},
+		{
+			name: "mixed",
+			statuses: []testGridStatus{
+				{Count: 2, Value: 1},
+				{Count: 1, Value: 12},
+				{Count: 3, Value: 0},
+			},
+			want: []int{1, 1, 12, 0, 0, 0},
+		},
+		{
+			name:     "empty",
+			statuses: nil,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandStatuses(tt.statuses)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d = %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFilterColumnsInRange(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("all in range", func(t *testing.T) {
+		timestamps := []int64{
+			now.Add(-1 * time.Hour).UnixMilli(),
+			now.Add(-2 * time.Hour).UnixMilli(),
+			now.Add(-3 * time.Hour).UnixMilli(),
+		}
+		indices, _, _ := filterColumnsInRange(timestamps, 1)
+		if len(indices) != 3 {
+			t.Errorf("got %d indices, want 3", len(indices))
+		}
+	})
+
+	t.Run("some out of range", func(t *testing.T) {
+		timestamps := []int64{
+			now.Add(-1 * time.Hour).UnixMilli(),
+			now.Add(-48 * time.Hour).UnixMilli(),
+			now.Add(-72 * time.Hour).UnixMilli(),
+		}
+		indices, _, _ := filterColumnsInRange(timestamps, 1)
+		if len(indices) != 1 {
+			t.Errorf("got %d indices, want 1", len(indices))
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		indices, _, _ := filterColumnsInRange(nil, 7)
+		if len(indices) != 0 {
+			t.Errorf("got %d indices, want 0", len(indices))
+		}
+	})
+}
+
+func TestAnalyzeLaneRate(t *testing.T) {
+	now := time.Now().UTC()
+
+	mockResponse := testGridTableResponse{
+		Timestamps: []int64{
+			now.Add(-1 * time.Hour).UnixMilli(),
+			now.Add(-2 * time.Hour).UnixMilli(),
+			now.Add(-3 * time.Hour).UnixMilli(),
+			now.Add(-4 * time.Hour).UnixMilli(),
+			now.Add(-5 * time.Hour).UnixMilli(),
+		},
+		ColumnIDs: []string{"build-5", "build-4", "build-3", "build-2", "build-1"},
+		Tests: []testGridTest{
+			{
+				Name: "suite.Overall",
+				Statuses: []testGridStatus{
+					{Count: 4, Value: 1},
+					{Count: 1, Value: 12},
+				},
+				Messages: []string{"", "", "", "", "overall fail"},
+			},
+			{
+				Name: "suite.[sig-storage] test-always-passes",
+				Statuses: []testGridStatus{
+					{Count: 5, Value: 1},
+				},
+				Messages: []string{"", "", "", "", ""},
+			},
+			{
+				Name: "suite.[sig-storage] test-sometimes-fails",
+				Statuses: []testGridStatus{
+					{Count: 3, Value: 1},
+					{Count: 2, Value: 12},
+				},
+				Messages: []string{"", "", "", "error msg 1", "error msg 2"},
+			},
+			{
+				Name: "suite.[sig-storage] test-always-fails",
+				Statuses: []testGridStatus{
+					{Count: 5, Value: 12},
+				},
+				Messages: []string{"fail1", "fail2", "fail3", "fail4", "fail5"},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(mockResponse)
+	}))
+	defer server.Close()
+
+	origURL := testgridBaseURL
+	testgridBaseURL = server.URL
+	defer func() { testgridBaseURL = origURL }()
+
+	result, err := AnalyzeLaneRate(server.URL+"/test-dashboard#test-tab", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Dashboard != "test-dashboard" {
+		t.Errorf("dashboard = %q, want %q", result.Dashboard, "test-dashboard")
+	}
+	if result.Tab != "test-tab" {
+		t.Errorf("tab = %q, want %q", result.Tab, "test-tab")
+	}
+	if result.TotalBuilds != 5 {
+		t.Errorf("total builds = %d, want 5", result.TotalBuilds)
+	}
+
+	// Should have 2 entries: sometimes-fails and always-fails
+	// Overall and always-passes should be excluded
+	if len(result.FailedTests) != 2 {
+		t.Fatalf("got %d failed tests, want 2", len(result.FailedTests))
+	}
+
+	// Sorted by success rate ascending — always-fails (0%) first
+	alwaysFails := result.FailedTests[0]
+	if alwaysFails.Failed != 5 {
+		t.Errorf("always-fails: failed = %d, want 5", alwaysFails.Failed)
+	}
+	if alwaysFails.Succeeded != 0 {
+		t.Errorf("always-fails: succeeded = %d, want 0", alwaysFails.Succeeded)
+	}
+	if alwaysFails.Severity != "likely-flaky" {
+		t.Errorf("always-fails: severity = %q, want %q", alwaysFails.Severity, "likely-flaky")
+	}
+
+	sometimesFails := result.FailedTests[1]
+	if sometimesFails.Failed != 2 {
+		t.Errorf("sometimes-fails: failed = %d, want 2", sometimesFails.Failed)
+	}
+	if sometimesFails.Succeeded != 3 {
+		t.Errorf("sometimes-fails: succeeded = %d, want 3", sometimesFails.Succeeded)
+	}
+	if sometimesFails.SuccessRate != 60.0 {
+		t.Errorf("sometimes-fails: success rate = %f, want 60.0", sometimesFails.SuccessRate)
+	}
+
+	if len(sometimesFails.RecentFailures) != 2 {
+		t.Errorf("sometimes-fails: recent failures = %d, want 2", len(sometimesFails.RecentFailures))
+	}
+	if sometimesFails.RecentFailures[0].Message != "error msg 1" {
+		t.Errorf("sometimes-fails: first failure message = %q, want %q", sometimesFails.RecentFailures[0].Message, "error msg 1")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `lane-rate` subcommand that analyzes all tests in a testgrid lane over a configurable time window (default 14 days)
- Computes per-test failure rates from raw testgrid pass/fail data, classifies severity, and captures recent failure messages
- Includes Claude Code skill definition for interactive lane analysis
- Complements the existing `test-rate` command (cross-lane view for specific tests) with a lane-wide health overview

## Test plan
- [x] `go build ./cmd/ci-failures/` compiles
- [x] Unit tests pass: `TestParseTestGridURL`, `TestExpandStatuses`, `TestFilterColumnsInRange`, `TestAnalyzeLaneRate`
- [x] Manual test against live testgrid lanes (k8s 1.34, 1.35, 1.36 sig-storage, S390X)
- [x] Verified YAML output structure and severity classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)