### PR TITLE
fix: update skill paths and detect 'command not found' errors

### DIFF
--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -18,12 +18,16 @@ It combines four analyses:
 
 ## Analysis data generation
 
-As a base for analyzing the failure, the go tool `cmd/ci-failures` from this project is to be used.
+As a base for analyzing the failure, the go tool `cmd/ci-failures` from the `kubevirt.io/ci-health` repository is to be used.
+
+The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
+- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
+- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
 
 Example how to generate the data files for a specific prowjob, given is the url to the prowjob build:
 
 ```bash
-$ go run ./cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
 ```
 
 This produces up to two output files in a session directory:

--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -20,14 +20,12 @@ It combines four analyses:
 
 As a base for analyzing the failure, the go tool `cmd/ci-failures` from the `kubevirt.io/ci-health` repository is to be used.
 
-The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
-- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
-- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
 
 Example how to generate the data files for a specific prowjob, given is the url to the prowjob build:
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
+$ go run ./cmd/ci-failures analyze-build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16885/pull-kubevirt-e2e-k8s-1.34-windows2016/2034979182789791744
 ```
 
 This produces up to two output files in a session directory:

--- a/.claude/skills/analyze-ci-failures/SKILL.md
+++ b/.claude/skills/analyze-ci-failures/SKILL.md
@@ -15,14 +15,12 @@ This skill helps the user to find the root cause and mitigations for all ci fail
 As a base for analyzing the failure, the go tool `cmd/ci-failures` from the `kubevirt.io/ci-health` repository is to be used. As a base for the data the file
 `output/kubevirt/kubevirt/results.json` is used.
 
-The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
-- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
-- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
 
 Example how to generate the data files for the prowjobs failing ci:
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures generate yaml
+$ go run ./cmd/ci-failures generate yaml
 ```
 
 This produces:

--- a/.claude/skills/analyze-ci-failures/SKILL.md
+++ b/.claude/skills/analyze-ci-failures/SKILL.md
@@ -12,13 +12,17 @@ This skill helps the user to find the root cause and mitigations for all ci fail
 
 ## Analysis data generation
 
-As a base for analyzing the failure, the go tool `cmd/ci-failures` from this project is to be used. As a base for the data the file
+As a base for analyzing the failure, the go tool `cmd/ci-failures` from the `kubevirt.io/ci-health` repository is to be used. As a base for the data the file
 `output/kubevirt/kubevirt/results.json` is used.
+
+The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
+- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
+- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
 
 Example how to generate the data files for the prowjobs failing ci:
 
 ```bash
-$ go run ./cmd/ci-failures generate yaml
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures generate yaml
 ```
 
 This produces:

--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -14,16 +14,14 @@ It works for any repo served by prow.ci.kubevirt.io (currently the `kubevirt` Gi
 
 ## Data Generation
 
-The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
-- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
-- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
 
 Two commands to run sequentially:
 
 ### Step 1: Fetch and analyze all failed builds
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures analyze-pr https://github.com/kubevirt/kubevirt/pull/17287
+$ go run ./cmd/ci-failures analyze-pr https://github.com/kubevirt/kubevirt/pull/17287
 ```
 
 This downloads build logs, k8s-reporter artifacts, and container logs for every currently-failing job in the PR. Output files go to the session directory.

--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -14,12 +14,16 @@ It works for any repo served by prow.ci.kubevirt.io (currently the `kubevirt` Gi
 
 ## Data Generation
 
+The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
+- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
+- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+
 Two commands to run sequentially:
 
 ### Step 1: Fetch and analyze all failed builds
 
 ```bash
-$ go run ./cmd/ci-failures analyze-pr https://github.com/kubevirt/kubevirt/pull/17287
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures analyze-pr https://github.com/kubevirt/kubevirt/pull/17287
 ```
 
 This downloads build logs, k8s-reporter artifacts, and container logs for every currently-failing job in the PR. Output files go to the session directory.

--- a/.claude/skills/flake-overview/SKILL.md
+++ b/.claude/skills/flake-overview/SKILL.md
@@ -17,20 +17,20 @@ Together they answer: "which tests are flaky, is it a PR-interaction problem or 
 
 ## Step 1: Locate the ci-health repository and run flake-overview twice
 
-Before running, determine the correct working directory:
-- If the current working directory already contains `cmd/ci-failures/`, you are inside the ci-health repo — run commands directly.
-- Otherwise, look for a `kubevirt.io/ci-health` subdirectory relative to the current working directory and `cd` into it before running.
+The `cmd/ci-failures` tool lives in the `kubevirt.io/ci-health` repository. The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
+- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
+- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
 
 Run the command twice — once for a 28-day window and once for a 7-day window — to enable trend detection:
 
 ```bash
-go run ./cmd/ci-failures flake-overview --days 28
+go run ./kubevirt.io/ci-health/cmd/ci-failures flake-overview --days 28
 ```
 
 Read the output YAML, then run:
 
 ```bash
-go run ./cmd/ci-failures flake-overview --days 7
+go run ./kubevirt.io/ci-health/cmd/ci-failures flake-overview --days 7
 ```
 
 Read that output YAML too. Both runs produce a file at `output/tmp/flake-overview.yaml` (or `output/tmp/sessions/{session-id}/flake-overview.yaml` when a session ID is set). The second run overwrites the first, so read the first output before running the second.

--- a/.claude/skills/flake-overview/SKILL.md
+++ b/.claude/skills/flake-overview/SKILL.md
@@ -17,20 +17,18 @@ Together they answer: "which tests are flaky, is it a PR-interaction problem or 
 
 ## Step 1: Locate the ci-health repository and run flake-overview twice
 
-The `cmd/ci-failures` tool lives in the `kubevirt.io/ci-health` repository. The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
-- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
-- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+The `cmd/ci-failures` tool lives in the `kubevirt.io/ci-health` repository. If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
 
 Run the command twice — once for a 28-day window and once for a 7-day window — to enable trend detection:
 
 ```bash
-go run ./kubevirt.io/ci-health/cmd/ci-failures flake-overview --days 28
+go run ./cmd/ci-failures flake-overview --days 28
 ```
 
 Read the output YAML, then run:
 
 ```bash
-go run ./kubevirt.io/ci-health/cmd/ci-failures flake-overview --days 7
+go run ./cmd/ci-failures flake-overview --days 7
 ```
 
 Read that output YAML too. Both runs produce a file at `output/tmp/flake-overview.yaml` (or `output/tmp/sessions/{session-id}/flake-overview.yaml` when a session ID is set). The second run overwrites the first, so read the first output before running the second.

--- a/.claude/skills/lane-failure-rate/SKILL.md
+++ b/.claude/skills/lane-failure-rate/SKILL.md
@@ -14,22 +14,26 @@ This skill analyzes a testgrid lane and calculates failure rates for every test 
 
 ## Data generation
 
-Run the `lane-rate` subcommand with a testgrid URL:
+Run the `lane-rate` subcommand from the `kubevirt.io/ci-health` repository with a testgrid URL.
+
+The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
+- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
+- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
 
 ```bash
-$ go run ./cmd/ci-failures lane-rate <testgrid-url>
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures lane-rate <testgrid-url>
 ```
 
 To control the analysis window (default 14 days):
 
 ```bash
-$ go run ./cmd/ci-failures lane-rate --days 21 <testgrid-url>
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures lane-rate --days 21 <testgrid-url>
 ```
 
 Example:
 
 ```bash
-$ go run ./cmd/ci-failures lane-rate --days 14 "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage"
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures lane-rate --days 14 "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage"
 ```
 
 This produces `output/tmp/lane-rate-{tab-name}.yaml`.

--- a/.claude/skills/lane-failure-rate/SKILL.md
+++ b/.claude/skills/lane-failure-rate/SKILL.md
@@ -16,24 +16,22 @@ This skill analyzes a testgrid lane and calculates failure rates for every test 
 
 Run the `lane-rate` subcommand from the `kubevirt.io/ci-health` repository with a testgrid URL.
 
-The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
-- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
-- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures lane-rate <testgrid-url>
+$ go run ./cmd/ci-failures lane-rate <testgrid-url>
 ```
 
 To control the analysis window (default 14 days):
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures lane-rate --days 21 <testgrid-url>
+$ go run ./cmd/ci-failures lane-rate --days 21 <testgrid-url>
 ```
 
 Example:
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures lane-rate --days 14 "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage"
+$ go run ./cmd/ci-failures lane-rate --days 14 "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage"
 ```
 
 This produces `output/tmp/lane-rate-{tab-name}.yaml`.

--- a/.claude/skills/test-failure-rate/SKILL.md
+++ b/.claude/skills/test-failure-rate/SKILL.md
@@ -13,22 +13,26 @@ This skill looks up the historical success rate for each test that failed in a P
 
 ## Data generation
 
-Run the `test-rate` subcommand with the Prow job URL:
+Run the `test-rate` subcommand from the `kubevirt.io/ci-health` repository with the Prow job URL.
+
+The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
+- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
+- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
 
 ```bash
-$ go run ./cmd/ci-failures test-rate <prow-job-url>
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures test-rate <prow-job-url>
 ```
 
 To cover a longer period (up to 28 days):
 
 ```bash
-$ go run ./cmd/ci-failures test-rate --days 14 <prow-job-url>
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures test-rate --days 14 <prow-job-url>
 ```
 
 Example:
 
 ```bash
-$ go run ./cmd/ci-failures test-rate --days 21 https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
+$ go run ./kubevirt.io/ci-health/cmd/ci-failures test-rate --days 21 https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
 ```
 
 This produces `output/tmp/sessions/<session-id>/test-rate-{job-name}.yaml`.

--- a/.claude/skills/test-failure-rate/SKILL.md
+++ b/.claude/skills/test-failure-rate/SKILL.md
@@ -15,24 +15,22 @@ This skill looks up the historical success rate for each test that failed in a P
 
 Run the `test-rate` subcommand from the `kubevirt.io/ci-health` repository with the Prow job URL.
 
-The skill may be executed from either the top-level `github.com` directory or directly inside the `ci-health` repository. Determine the correct path to the tool based on the current working directory:
-- From `github.com/`: `go run ./kubevirt.io/ci-health/cmd/ci-failures ...`
-- From `kubevirt.io/ci-health/`: `go run ./cmd/ci-failures ...`
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures test-rate <prow-job-url>
+$ go run ./cmd/ci-failures test-rate <prow-job-url>
 ```
 
 To cover a longer period (up to 28 days):
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures test-rate --days 14 <prow-job-url>
+$ go run ./cmd/ci-failures test-rate --days 14 <prow-job-url>
 ```
 
 Example:
 
 ```bash
-$ go run ./kubevirt.io/ci-health/cmd/ci-failures test-rate --days 21 https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
+$ go run ./cmd/ci-failures test-rate --days 21 https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17690/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2053739485539078144
 ```
 
 This produces `output/tmp/sessions/<session-id>/test-rate-{job-name}.yaml`.

--- a/pkg/ci-failures/categorize.go
+++ b/pkg/ci-failures/categorize.go
@@ -100,6 +100,9 @@ var rules = []categoryRule{
 	{CategoryInternal, "control plane startup failure", regexp.MustCompile(`error.*execution phase wait-control-plane: failed while waiting for the control plane to start`)},
 	// Kind cluster creation failure (log line pattern not found)
 	{CategoryInternal, "kind cluster creation failure", regexp.MustCompile(`ERROR: failed to create cluster: could not find a log line that matches`)},
+
+	// Missing binary in CI container/environment
+	{CategoryInternal, "missing command in CI environment", regexp.MustCompile(`command not found`)},
 }
 
 type contextExternalPattern struct {

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -24,7 +24,7 @@ const logsDir = "output/tmp/build-logs"
 var (
 	// Regex to find errors in log files
 	// make: *** [Makefile:174: cluster-sync] Error 125
-	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |^make:.*Error (1[0-9]+|[2-9][0-9]*)`)
+	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |^make:.*Error (1[0-9]+|[2-9][0-9]*)|command not found`)
 )
 
 // ShowCIFailureJobs fetches URLs for the CI failure runs from the data of the latest run.


### PR DESCRIPTION
## Summary

- Update all skills that use `cmd/ci-failures` to reference the `kubevirt.io/ci-health` repository explicitly, with correct paths for both execution contexts (`github.com/` root vs `ci-health/` directly)
- Add `command not found` to the build log error extraction regex and categorize it as `internal` / `missing command in CI environment`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/ci-failures/...` passes
- [x] Re-ran `analyze-build` against [kubevirtci#1702 check-provision-k8s-1.36](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1702/check-provision-k8s-1.36/2057019613232762880) — now correctly detects `crictl: command not found` and categorizes as `internal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)