### PR TITLE
feat: add discover-lanes subcommand and lane-rate max-success-rate filter

### DIFF
--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -126,8 +126,9 @@ Accepts a Prow job URL, e.g.:
 		RunE: analyzeK8s,
 	}
 
-	testRateDays         int
-	laneRateDays         int
+	testRateDays            int
+	laneRateDays            int
+	laneRateMaxSuccessRate  float64
 	flakeOverviewDays    int
 	flakeOverviewFilter  string
 	flakeOverviewConc    int
@@ -185,6 +186,20 @@ directory and emit a single condensed YAML summary to stdout.
 
 Requires a session ID (via --session-id flag or CLAUDE_CODE_SESSION_ID env var).`,
 		RunE: summarizeSession,
+	}
+
+	discoverLanesCmd = &cobra.Command{
+		Use:   "discover-lanes [version]",
+		Short: "Discover testgrid lanes for a Kubernetes version.",
+		Long: `Query testgrid summary API for both kubevirt-periodics and kubevirt-presubmits
+dashboards and list all lanes matching the given Kubernetes version.
+
+Accepts a version string, e.g.:
+  1.36
+
+Outputs a YAML file with all matching lanes and their overall status.`,
+		Args: cobra.ExactArgs(1),
+		RunE: discoverLanes,
 	}
 )
 
@@ -492,7 +507,7 @@ func flakeOverview(_ *cobra.Command, _ []string) error {
 func laneRate(_ *cobra.Command, args []string) error {
 	testgridURL := args[0]
 
-	result, err := cifailures.AnalyzeLaneRate(testgridURL, laneRateDays)
+	result, err := cifailures.AnalyzeLaneRate(testgridURL, laneRateDays, laneRateMaxSuccessRate)
 	if err != nil {
 		return fmt.Errorf("failed to analyze lane rate: %w", err)
 	}
@@ -508,6 +523,31 @@ func laneRate(_ *cobra.Command, args []string) error {
 	}
 
 	log.Infof("wrote lane rate analysis to %s (%d tests with failures)", outputPath, len(result.FailedTests))
+	return nil
+}
+
+func discoverLanes(_ *cobra.Command, args []string) error {
+	version := args[0]
+
+	result, err := cifailures.DiscoverLanes(version)
+	if err != nil {
+		return fmt.Errorf("failed to discover lanes: %w", err)
+	}
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpOutputPath, fmt.Sprintf("discover-lanes-%s.yaml", version))
+	if err = cifailures.WriteDiscoverLanesResultYAML(outputPath, result); err != nil {
+		return fmt.Errorf("failed to write YAML output: %w", err)
+	}
+
+	var totalLanes int
+	for _, d := range result.Dashboards {
+		totalLanes += len(d.Lanes)
+	}
+	log.Infof("wrote lane discovery to %s (%d lanes across %d dashboards)", outputPath, totalLanes, len(result.Dashboards))
 	return nil
 }
 
@@ -537,6 +577,7 @@ func init() {
 
 	testRateCmd.Flags().IntVar(&testRateDays, "days", 7, "Number of days to cover (max 28, fetches multiple weekly reports)")
 	laneRateCmd.Flags().IntVar(&laneRateDays, "days", 14, "Number of days to analyze (default 14)")
+	laneRateCmd.Flags().Float64Var(&laneRateMaxSuccessRate, "max-success-rate", 100, "Only include tests with success rate at or below this threshold (0-100)")
 	flakeOverviewCmd.Flags().IntVar(&flakeOverviewDays, "days", 14, "Number of days to analyze (default 14)")
 	flakeOverviewCmd.Flags().StringVar(&flakeOverviewFilter, "filter-lane-regex", `.*-root$`, "Regex for lanes to exclude")
 	flakeOverviewCmd.Flags().IntVar(&flakeOverviewConc, "concurrency", 6, "Parallel testgrid fetches (default 6)")
@@ -550,6 +591,7 @@ func init() {
 	rootCmd.AddCommand(flakeOverviewCmd)
 	rootCmd.AddCommand(changeRelevanceCmd)
 	rootCmd.AddCommand(summarizeSessionCmd)
+	rootCmd.AddCommand(discoverLanesCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/ci-failures/discover_lanes.go
+++ b/pkg/ci-failures/discover_lanes.go
@@ -1,0 +1,109 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+var testgridDashboards = []string{
+	"kubevirt-periodics",
+	"kubevirt-presubmits",
+}
+
+type DiscoverLanesResult struct {
+	VersionFilter string                    `yaml:"version_filter"`
+	Dashboards    []DiscoverLanesDashboard   `yaml:"dashboards"`
+}
+
+type DiscoverLanesDashboard struct {
+	Name  string               `yaml:"name"`
+	Lanes []DiscoverLanesEntry `yaml:"lanes"`
+}
+
+type DiscoverLanesEntry struct {
+	Tab           string `yaml:"tab"`
+	OverallStatus string `yaml:"overall_status"`
+	TestGridURL   string `yaml:"testgrid_url"`
+}
+
+type testgridSummaryEntry struct {
+	OverallStatus string `json:"overall_status"`
+}
+
+func fetchDashboardSummary(dashboard string) (map[string]testgridSummaryEntry, error) {
+	apiURL := fmt.Sprintf("%s/%s/summary", testgridBaseURL, dashboard)
+	log.Infof("fetching testgrid summary from %s", apiURL)
+
+	resp, err := httpClient.Get(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch testgrid summary: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("testgrid returned status %d for %s", resp.StatusCode, apiURL)
+	}
+
+	var summary map[string]testgridSummaryEntry
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		return nil, fmt.Errorf("failed to decode testgrid summary: %w", err)
+	}
+
+	return summary, nil
+}
+
+func DiscoverLanes(version string) (*DiscoverLanesResult, error) {
+	result := &DiscoverLanesResult{
+		VersionFilter: version,
+	}
+
+	for _, dashboard := range testgridDashboards {
+		summary, err := fetchDashboardSummary(dashboard)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch summary for %s: %w", dashboard, err)
+		}
+
+		var entries []DiscoverLanesEntry
+		for tab, entry := range summary {
+			if !strings.Contains(tab, version) {
+				continue
+			}
+			entries = append(entries, DiscoverLanesEntry{
+				Tab:           tab,
+				OverallStatus: entry.OverallStatus,
+				TestGridURL:   fmt.Sprintf("%s/%s#%s", testgridBaseURL, dashboard, tab),
+			})
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Tab < entries[j].Tab
+		})
+
+		result.Dashboards = append(result.Dashboards, DiscoverLanesDashboard{
+			Name:  dashboard,
+			Lanes: entries,
+		})
+	}
+
+	return result, nil
+}
+
+func WriteDiscoverLanesResultYAML(outputPath string, result *DiscoverLanesResult) error {
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+	}
+	defer outputFile.Close()
+
+	encoder := yaml.NewEncoder(outputFile)
+	if err := encoder.Encode(result); err != nil {
+		return fmt.Errorf("failed to encode YAML: %w", err)
+	}
+	return nil
+}

--- a/pkg/ci-failures/lane_rate.go
+++ b/pkg/ci-failures/lane_rate.go
@@ -149,7 +149,7 @@ func filterColumnsInRange(timestamps []int64, days int) (indices []int, periodSt
 	return indices, periodStart, periodEnd
 }
 
-func AnalyzeLaneRate(testgridURL string, days int) (*LaneRateResult, error) {
+func AnalyzeLaneRate(testgridURL string, days int, maxSuccessRate ...float64) (*LaneRateResult, error) {
 	dashboard, tab, err := ParseTestGridURL(testgridURL)
 	if err != nil {
 		return nil, err
@@ -227,6 +227,17 @@ func AnalyzeLaneRate(testgridURL string, days int) (*LaneRateResult, error) {
 			Severity:       classifySeverity(successRate, totalRuns),
 			RecentFailures: recentFailures,
 		})
+	}
+
+	if len(maxSuccessRate) > 0 && maxSuccessRate[0] < 100 {
+		threshold := maxSuccessRate[0]
+		filtered := entries[:0]
+		for _, e := range entries {
+			if e.SuccessRate <= threshold {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
 	}
 
 	sort.Slice(entries, func(i, j int) bool {


### PR DESCRIPTION
## Summary

- Add `discover-lanes` subcommand that queries the testgrid summary API for both `kubevirt-periodics` and `kubevirt-presubmits` dashboards to list all lanes matching a given Kubernetes version (e.g. `go run ./cmd/ci-failures discover-lanes 1.36`)
- Add `--max-success-rate` flag to `lane-rate` to filter out tests above a success rate threshold (e.g. `--max-success-rate 95` to focus on tests with meaningful failure patterns in noisy presubmit lanes)

## Test plan

- [ ] `go build ./cmd/ci-failures` succeeds
- [ ] `go vet ./cmd/ci-failures/... ./pkg/ci-failures/...` passes
- [ ] `go run ./cmd/ci-failures discover-lanes 1.36` produces YAML listing lanes from both dashboards
- [ ] `go run ./cmd/ci-failures lane-rate <url>` without `--max-success-rate` produces unchanged output (default 100 = no filtering)
- [ ] `go run ./cmd/ci-failures lane-rate --max-success-rate 95 <presubmit-url>` filters to only tests at or below 95%
- [ ] Existing `flake-overview` command still works (calls `AnalyzeLaneRate` without the optional parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)