### PR TITLE
feat(ci-failures): add show-log command and improve skill workflow

### DIFF
--- a/.claude/skills/analyze-ci-failures/SKILL.md
+++ b/.claude/skills/analyze-ci-failures/SKILL.md
@@ -3,7 +3,7 @@ name: analyze-ci-failures
 description: >
     Analyze root causes for all the recent ci-failures.
     Use when user mentions to analyze recent ci failures
-allowed-tools: [Read, Write, Glob, Grep, Bash(go run:*), Bash(stat:*), Bash(ls:*), Bash(git fetch:*), Bash(git diff:*)]
+allowed-tools: [Read, Write, Grep, Bash(go run:*), Bash(stat:*), Bash(ls:*), Bash(git fetch:*), Bash(git diff:*)]
 ---
 
 ## Overview
@@ -26,6 +26,15 @@ $ go run ./cmd/ci-failures generate yaml
 This produces:
 - `output/tmp/errors-{sig}/*.yaml` — per-job error extractions with snippets, line links, and context
 - `output/tmp/build-logs/{buildID}.yaml` — full cached build logs with prow URL, GCS URL, timestamps, and complete log content
+
+At the end of execution, the command prints a YAML list of all generated error files to stdout:
+```
+generated_files:
+  - output/tmp/errors-sig-compute/pull-kubevirt-e2e-k8s-1.35-sig-compute.yaml
+  - output/tmp/errors-sig-network/pull-kubevirt-e2e-k8s-1.35-sig-network.yaml
+  ...
+```
+Parse this list to know exactly which files to read — no separate file discovery step (find/glob) is needed.
 
 ### Stale data
 Before you proceed, 
@@ -66,20 +75,26 @@ Each file contains structured data — most metadata can be read directly withou
 
 ### Full build log files (`output/tmp/build-logs/{buildID}.yaml`)
 
-Only needed when error snippets are insufficient for root cause analysis. Structure:
-- `prow_job_url`: link to the Prow job
-- `build_log_url`: GCS URL for the raw build log
-- `log_content`: the complete build log text
-- `started` / `finished`: timestamps
+Only needed when error snippets are insufficient for root cause analysis. Use the `show-log` command to read decoded build logs instead of reading the YAML files directly (they contain base64-encoded binary content):
 
-These files can be very large. When reading them, start searching from the end since failures appear at the bottom.
+```bash
+# Show last 30 lines of a build log
+$ go run ./cmd/ci-failures show-log <build-id> --tail 30
+
+# Search for error patterns (case-insensitive)
+$ go run ./cmd/ci-failures show-log <build-id> --grep "error" --tail 20
+```
+
+Flags:
+- `--tail N` — print only the last N lines (default: all)
+- `--grep pattern` — filter lines containing the pattern (case-insensitive); output includes line numbers
 
 ## Procedure
 
-1. **Discover error files**: Use Glob to find all `output/tmp/errors-*/*.yaml` files
+1. **Use generated file list**: Parse the `generated_files:` YAML list printed by the `generate yaml` command to get all error YAML file paths — no separate discovery step needed
 2. **Read each error YAML file**: Extract the job name, SIG (from directory), and all build errors with their snippets
 3. **Analyze error snippets**: For each build error, examine `error_text` and `context` fields to determine root cause. In most cases the snippets contain enough information
-4. **Deep-dive when needed**: If snippets are ambiguous, read the full build log from `output/tmp/build-logs/{build_id}.yaml`
+4. **Deep-dive when needed**: If snippets are ambiguous or empty, use `go run ./cmd/ci-failures show-log <build_id> --grep "error" --tail 20` to search the full build log
 5. **Classify** each failure as fixable or non-fixable
 6. **Group similar failures** across jobs — errors with the same root cause should be combined into a single group even if they appear in different SIGs or branches
 

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -132,6 +132,8 @@ Accepts a Prow job URL, e.g.:
 	flakeOverviewDays    int
 	flakeOverviewFilter  string
 	flakeOverviewConc    int
+	showLogTail  int
+	showLogGrep  string
 
 	testRateCmd = &cobra.Command{
 		Use:   "test-rate [prow-job-url]",
@@ -188,6 +190,18 @@ Requires a session ID (via --session-id flag or CLAUDE_CODE_SESSION_ID env var).
 		RunE: summarizeSession,
 	}
 
+	showLogCmd = &cobra.Command{
+		Use:   "show-log [build-id]",
+		Short: "Print decoded build log content from a cached build log YAML file.",
+		Long: `Read a cached build log YAML file (output/tmp/build-logs/{build-id}.yaml),
+decode the binary log content, and print it to stdout.
+
+Use --tail to print only the last N lines (default: all).
+Use --grep to filter lines matching a pattern (case-insensitive).`,
+		Args: cobra.ExactArgs(1),
+		RunE: showLog,
+	}
+
 	discoverLanesCmd = &cobra.Command{
 		Use:   "discover-lanes [version]",
 		Short: "Discover testgrid lanes for a Kubernetes version.",
@@ -231,9 +245,13 @@ func generateYAML(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed downloading build logs: %v", err)
 	}
-	_, err = cifailures.ExtractErrors(ciFailureJobURLs, tmpOutputPath)
+	outputFiles, err := cifailures.ExtractErrors(ciFailureJobURLs, tmpOutputPath)
 	if err != nil {
 		return fmt.Errorf("failed extracting errors from build logs: %v", err)
+	}
+	fmt.Println("generated_files:")
+	for _, f := range outputFiles {
+		fmt.Printf("  - %s\n", f)
 	}
 	return nil
 }
@@ -568,6 +586,40 @@ func summarizeSession(_ *cobra.Command, _ []string) error {
 	return encoder.Close()
 }
 
+func showLog(_ *cobra.Command, args []string) error {
+	buildID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid build ID %q: %v", args[0], err)
+	}
+
+	content, err := cifailures.ReadBuildLogByID(buildID)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(content, "\n")
+
+	if showLogGrep != "" {
+		pattern := strings.ToLower(showLogGrep)
+		var matched []string
+		for i, line := range lines {
+			if strings.Contains(strings.ToLower(line), pattern) {
+				matched = append(matched, fmt.Sprintf("%d: %s", i+1, line))
+			}
+		}
+		lines = matched
+	}
+
+	if showLogTail > 0 && showLogTail < len(lines) {
+		lines = lines[len(lines)-showLogTail:]
+	}
+
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+	return nil
+}
+
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
@@ -582,6 +634,9 @@ func init() {
 	flakeOverviewCmd.Flags().StringVar(&flakeOverviewFilter, "filter-lane-regex", `.*-root$`, "Regex for lanes to exclude")
 	flakeOverviewCmd.Flags().IntVar(&flakeOverviewConc, "concurrency", 6, "Parallel testgrid fetches (default 6)")
 
+	showLogCmd.Flags().IntVar(&showLogTail, "tail", 0, "Print only the last N lines (0 = all)")
+	showLogCmd.Flags().StringVar(&showLogGrep, "grep", "", "Filter lines containing this pattern (case-insensitive)")
+
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(analyzeBuildCmd)
 	rootCmd.AddCommand(analyzePRCmd)
@@ -592,6 +647,7 @@ func init() {
 	rootCmd.AddCommand(changeRelevanceCmd)
 	rootCmd.AddCommand(summarizeSessionCmd)
 	rootCmd.AddCommand(discoverLanesCmd)
+	rootCmd.AddCommand(showLogCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -4,19 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kubevirt/ci-health/pkg/prow"
-	"github.com/kubevirt/ci-health/pkg/sigretests"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kubevirt/ci-health/pkg/prow"
+	"github.com/kubevirt/ci-health/pkg/sigretests"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 const logsDir = "output/tmp/build-logs"
@@ -260,7 +262,18 @@ func ExtractErrors(ciFailureJobURLs []string, outputDir string) ([]string, error
 		log.Warnf("unmatched job urls: %v+", urlsNotMatchedByGroup)
 	}
 
+	slices.Sort(outputFiles)
 	return outputFiles, nil
+}
+
+// ReadBuildLogByID reads a cached build log YAML file by build ID and returns its decoded content.
+func ReadBuildLogByID(buildID int) (string, error) {
+	logFilePath := filepath.Join(logsDir, fmt.Sprintf("%d.yaml", buildID))
+	bl, err := readBuildLog(logFilePath)
+	if err != nil {
+		return "", err
+	}
+	return bl.LogContent, nil
 }
 
 func readBuildLog(logFilePath string) (*buildLog, error) {


### PR DESCRIPTION
## Summary

- Add `show-log` CLI command that decodes cached build log YAML files and prints content to stdout, with `--tail` and `--grep` flags for targeted inspection
- Update `generate yaml` to print the list of generated error file paths to stdout, removing the need for a separate find/glob discovery step
- Update `analyze-ci-failures` skill to use both improvements (no more Glob tool, no more Python one-liners)

## Test plan

- [ ] `go build ./cmd/ci-failures/` compiles cleanly
- [ ] `go run ./cmd/ci-failures show-log <build-id> --tail 30` prints last 30 lines
- [ ] `go run ./cmd/ci-failures show-log <build-id> --grep "error"` filters lines with line numbers
- [ ] `go run ./cmd/ci-failures generate yaml` prints `generated_files:` list to stdout
- [ ] Run `/analyze-ci-failures` skill end-to-end — no find/glob step needed

🤖 Assisted by Claude