### PR TITLE
Onboard CodeRabbit and enable golangci-lint standard linters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,21 @@
+language: "en-US"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  tools:
+    enabled: true
+    golangci-lint:
+      enabled: true
+  path_filters:
+    - "!vendor/**"
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Ensure all errors are handled. Flag unhandled error returns.
+        Check for concurrency issues (race conditions, mutex misuse).
+        Follow Go naming conventions and effective Go idioms.
+    - path: "**/*_test.go"
+      instructions: |
+        Verify table-driven tests where appropriate.
+        Check for proper test cleanup and resource management.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+linters:
+  default: standard
+  disable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+formatters:
+  enable:
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ version: "2"
 linters:
   default: standard
   disable:
-    - staticcheck
     - unused
 
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ version: "2"
 linters:
   default: standard
   disable:
-    - govet
     - ineffassign
     - staticcheck
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ version: "2"
 
 linters:
   default: standard
-  disable:
-    - unused
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ version: "2"
 linters:
   default: standard
   disable:
-    - errcheck
     - govet
     - ineffassign
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ version: "2"
 linters:
   default: standard
   disable:
-    - ineffassign
     - staticcheck
     - unused
 

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -126,14 +126,14 @@ Accepts a Prow job URL, e.g.:
 		RunE: analyzeK8s,
 	}
 
-	testRateDays            int
-	laneRateDays            int
-	laneRateMaxSuccessRate  float64
-	flakeOverviewDays    int
-	flakeOverviewFilter  string
-	flakeOverviewConc    int
-	showLogTail  int
-	showLogGrep  string
+	testRateDays           int
+	laneRateDays           int
+	laneRateMaxSuccessRate float64
+	flakeOverviewDays      int
+	flakeOverviewFilter    string
+	flakeOverviewConc      int
+	showLogTail            int
+	showLogGrep            string
 
 	testRateCmd = &cobra.Command{
 		Use:   "test-rate [prow-job-url]",

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -262,7 +262,11 @@ func writeCIFailureJobsURLFile(ciFailureJobURLs []string) error {
 	if err != nil {
 		return fmt.Errorf("failed creating ci failure jobs file: %v", err)
 	}
-	defer ciFailureJobsFile.Close()
+	defer func() {
+		if err := ciFailureJobsFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing ci failure jobs file")
+		}
+	}()
 	_, err = io.WriteString(ciFailureJobsFile, strings.Join(ciFailureJobURLs, "\n"))
 	if err != nil {
 		return fmt.Errorf("failed writing ci failure jobs file: %v", err)

--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -299,6 +299,9 @@ func generateMarkdown(_ *cobra.Command, _ []string) error {
 	// Deserialize JobBuildErrors files
 	for _, fileName := range files {
 		file, err := os.Open(fileName)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q: %v", fileName, err)
+		}
 		var jobBuildErrors *cifailures.JobBuildErrors
 		err = yaml.NewDecoder(file).Decode(&jobBuildErrors)
 		if err != nil {

--- a/cmd/ci-failures/types.go
+++ b/cmd/ci-failures/types.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	cifailures "github.com/kubevirt/ci-health/pkg/ci-failures"
 	"sort"
+
+	cifailures "github.com/kubevirt/ci-health/pkg/ci-failures"
 )
 
 type ShareCategory struct {

--- a/e2e/tests_suite_test.go
+++ b/e2e/tests_suite_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,7 +65,7 @@ var _ = BeforeSuite(func() {
 
 var _ = Describe("ci-health stats", func() {
 	It("Retrieves data from github and writes badges", func() {
-		artifactsDir, err := ioutil.TempDir("", "e2e-ci-health")
+		artifactsDir, err := os.MkdirTemp("", "e2e-ci-health")
 		Expect(err).ToNot(HaveOccurred())
 
 		opt := &types.Options{
@@ -117,7 +116,7 @@ var _ = Describe("ci-health stats", func() {
 
 		By("Checking JSON file")
 		jsonFileName := filepath.Join(sourceArtifactsDir, constants.JSONResultsFileName)
-		jsonData, err := ioutil.ReadFile(jsonFileName)
+		jsonData, err := os.ReadFile(jsonFileName)
 		Expect(err).ToNot(HaveOccurred())
 
 		var jsonResults types.Results
@@ -128,7 +127,7 @@ var _ = Describe("ci-health stats", func() {
 
 		By("Checking metrics file")
 		metricsFileName := filepath.Join(artifactsDir, constants.MetricsFileName)
-		metricsDataBytes, err := ioutil.ReadFile(metricsFileName)
+		metricsDataBytes, err := os.ReadFile(metricsFileName)
 		Expect(err).ToNot(HaveOccurred())
 		metricsData := string(metricsDataBytes)
 

--- a/pkg/chatops/chatops_test.go
+++ b/pkg/chatops/chatops_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/kubevirt/ci-health/pkg/types"
 )
 
-const (
-	retestComment = "/retest"
-)
-
 func TestChatops(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "chatops Suite")
@@ -23,7 +19,6 @@ func TestChatops(t *testing.T) {
 
 var (
 	queryDate = time.Date(2021, time.Month(1), 22, 15, 11, 26, 0, time.UTC)
-	zeroDate  = time.Time{}
 )
 
 var _ = Describe("RetestComments", func() {

--- a/pkg/chatops/main.go
+++ b/pkg/chatops/main.go
@@ -57,7 +57,7 @@ func RetestComments(pr *types.ChatopsPullRequestFragment) int {
 
 	lastPush := determineLastPush(pr)
 
-	for _, timelineItem := range pr.TimelineItems.Nodes {
+	for _, timelineItem := range pr.Nodes {
 		if strings.Contains(timelineItem.BodyText, phase2Intro) {
 			continue
 		}
@@ -72,9 +72,9 @@ func determineLastPush(pr *types.ChatopsPullRequestFragment) time.Time {
 	lastPush := zeroDate
 
 	var itemDate time.Time
-	for _, timelineItem := range pr.TimelineItems.Nodes {
+	for _, timelineItem := range pr.Nodes {
 		if isCommit(timelineItem) {
-			itemDate = timelineItem.PullRequestCommitFragment.Commit.CommittedDate
+			itemDate = timelineItem.Commit.CommittedDate
 		} else if isHeadRefForcePush(timelineItem) {
 			itemDate = timelineItem.HeadRefForcePushFragment.CreatedAt
 		} else if isBaseRefForcePush(timelineItem) {
@@ -103,5 +103,5 @@ func isBaseRefForcePush(timelineItem types.TimelineItem) bool {
 func isRetestCommentAfterLastPush(timelineItem types.TimelineItem, lastPush time.Time) bool {
 	return timelineItem.IssueCommentFragment != types.IssueCommentFragment{} &&
 		timelineItem.IssueCommentFragment.CreatedAt.After(lastPush) &&
-		(strings.HasPrefix(timelineItem.IssueCommentFragment.BodyText, "/retest"))
+		(strings.HasPrefix(timelineItem.BodyText, "/retest"))
 }

--- a/pkg/ci-failures/analyze.go
+++ b/pkg/ci-failures/analyze.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -90,7 +91,11 @@ func WriteJobBuildErrorsYAML(outputPath string, jobBuildErrors *JobBuildErrors) 
 	if err != nil {
 		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(jobBuildErrors); err != nil {

--- a/pkg/ci-failures/change_relevance.go
+++ b/pkg/ci-failures/change_relevance.go
@@ -176,16 +176,16 @@ func FetchPRChangedFiles(org, repo string, prNumber int) ([]string, error) {
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 			return nil, fmt.Errorf("GitHub API returned status %d for %s", resp.StatusCode, apiURL)
 		}
 
 		var files []ghPRFile
 		if err := json.NewDecoder(resp.Body).Decode(&files); err != nil {
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 			return nil, fmt.Errorf("failed to decode GitHub API response: %w", err)
 		}
-		resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck
 
 		for _, f := range files {
 			allFiles = append(allFiles, f.Filename)
@@ -345,7 +345,11 @@ func WriteChangeRelevanceResultYAML(outputPath string, result *ChangeRelevanceRe
 	if err != nil {
 		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(result); err != nil {

--- a/pkg/ci-failures/change_relevance_test.go
+++ b/pkg/ci-failures/change_relevance_test.go
@@ -238,7 +238,7 @@ func TestFetchPRChangedFiles(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(files)
+		json.NewEncoder(w).Encode(files) //nolint:errcheck
 	}))
 	defer server.Close()
 
@@ -266,9 +266,9 @@ func TestFetchPRChangedFilesPagination(t *testing.T) {
 		page := r.URL.Query().Get("page")
 		w.Header().Set("Content-Type", "application/json")
 		if page == "2" {
-			json.NewEncoder(w).Encode(page2)
+			json.NewEncoder(w).Encode(page2) //nolint:errcheck
 		} else {
-			json.NewEncoder(w).Encode(page1)
+			json.NewEncoder(w).Encode(page1) //nolint:errcheck
 		}
 	}))
 	defer server.Close()

--- a/pkg/ci-failures/cluster.go
+++ b/pkg/ci-failures/cluster.go
@@ -1,8 +1,9 @@
 package cifailures
 
 import (
-	"github.com/hyperjumptech/beda"
 	"sort"
+
+	"github.com/hyperjumptech/beda"
 )
 
 // ClusterErrors groups similar errors together.

--- a/pkg/ci-failures/discover_lanes.go
+++ b/pkg/ci-failures/discover_lanes.go
@@ -17,8 +17,8 @@ var testgridDashboards = []string{
 }
 
 type DiscoverLanesResult struct {
-	VersionFilter string                    `yaml:"version_filter"`
-	Dashboards    []DiscoverLanesDashboard   `yaml:"dashboards"`
+	VersionFilter string                   `yaml:"version_filter"`
+	Dashboards    []DiscoverLanesDashboard `yaml:"dashboards"`
 }
 
 type DiscoverLanesDashboard struct {

--- a/pkg/ci-failures/discover_lanes.go
+++ b/pkg/ci-failures/discover_lanes.go
@@ -44,7 +44,11 @@ func fetchDashboardSummary(dashboard string) (map[string]testgridSummaryEntry, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch testgrid summary: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("testgrid returned status %d for %s", resp.StatusCode, apiURL)
@@ -99,7 +103,11 @@ func WriteDiscoverLanesResultYAML(outputPath string, result *DiscoverLanesResult
 	if err != nil {
 		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(result); err != nil {

--- a/pkg/ci-failures/flake_overview.go
+++ b/pkg/ci-failures/flake_overview.go
@@ -58,7 +58,11 @@ func fetchFlakefinder24hReport(reportURL string) (*FlakefinderReport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch %s: %w", reportURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, reportURL)
@@ -233,7 +237,11 @@ func WriteFlakeOverviewResultYAML(outputPath string, result *FlakeOverviewResult
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", outputPath, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(f)
 	if err := encoder.Encode(result); err != nil {

--- a/pkg/ci-failures/flake_overview_test.go
+++ b/pkg/ci-failures/flake_overview_test.go
@@ -37,8 +37,8 @@ func TestAggregateLaneFailures(t *testing.T) {
 			Tests: []string{"test-a", "test-b"},
 			Data: map[string]map[string]*TestDetails{
 				"test-a": {
-					"periodic-kubevirt-e2e-k8s-1.36-sig-compute":      {Failed: 3},
-					"pull-kubevirt-e2e-k8s-1.35-sig-compute":          {Failed: 1},
+					"periodic-kubevirt-e2e-k8s-1.36-sig-compute": {Failed: 3},
+					"pull-kubevirt-e2e-k8s-1.35-sig-compute":     {Failed: 1},
 				},
 				"test-b": {
 					"periodic-kubevirt-e2e-k8s-1.36-sig-compute":      {Failed: 2},

--- a/pkg/ci-failures/k8s_analyze.go
+++ b/pkg/ci-failures/k8s_analyze.go
@@ -543,7 +543,11 @@ func downloadContainerLog(gcsURL, cacheDir, fileName string) (string, int64, err
 	if err != nil {
 		return "", 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", 0, fmt.Errorf("failed to download log from GCS: status %d", resp.StatusCode)
@@ -553,7 +557,11 @@ func downloadContainerLog(gcsURL, cacheDir, fileName string) (string, int64, err
 	if err != nil {
 		return "", 0, err
 	}
-	defer out.Close()
+	defer func() {
+		if err := out.Close(); err != nil {
+			log.WithError(err).Warn("failed closing cached log file")
+		}
+	}()
 
 	size, err := io.Copy(out, resp.Body)
 	if err != nil {
@@ -584,7 +592,11 @@ func WriteK8sAnalysisResultYAML(outputPath string, result *K8sAnalysisResult) er
 	if err != nil {
 		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(result); err != nil {

--- a/pkg/ci-failures/k8s_analyze_test.go
+++ b/pkg/ci-failures/k8s_analyze_test.go
@@ -471,12 +471,12 @@ func TestFetchEtcdProfileNotPresent(t *testing.T) {
 
 func TestParseContainerLogFileName(t *testing.T) {
 	tests := []struct {
-		name          string
-		fileName      string
-		expectOK      bool
-		expectNS      string
-		expectPod     string
-		expectCont    string
+		name       string
+		fileName   string
+		expectOK   bool
+		expectNS   string
+		expectPod  string
+		expectCont string
 	}{
 		{
 			name:       "virt-controller log",

--- a/pkg/ci-failures/k8s_analyze_test.go
+++ b/pkg/ci-failures/k8s_analyze_test.go
@@ -268,7 +268,7 @@ func TestDownloadK8sArtifactCaching(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		fmt.Fprint(w, podJSON)
+		fmt.Fprint(w, podJSON) //nolint:errcheck
 	}))
 	defer server.Close()
 
@@ -382,10 +382,10 @@ func TestFetchJobTimestamps(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/started.json", func(w http.ResponseWriter, r *http.Request) {
-		w.Write(startedJSON)
+		w.Write(startedJSON) //nolint:errcheck
 	})
 	mux.HandleFunc("/finished.json", func(w http.ResponseWriter, r *http.Request) {
-		w.Write(finishedJSON)
+		w.Write(finishedJSON) //nolint:errcheck
 	})
 
 	server := httptest.NewServer(mux)
@@ -430,7 +430,7 @@ func TestFetchEtcdProfile(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		fmt.Fprint(w, profileJSON)
+		fmt.Fprint(w, profileJSON) //nolint:errcheck
 	})
 	mux.HandleFunc("/", notFound)
 
@@ -569,7 +569,7 @@ func TestListAndFilterContainerLogs(t *testing.T) {
 				{Name: "prefix/suite/0_kubevirt_virt-controller-abc123-virt-controller_previous.log", Size: "900"},
 			},
 		}
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
 	})
 
 	server := httptest.NewServer(mux)
@@ -625,7 +625,7 @@ func TestListAndFilterContainerLogsPagination(t *testing.T) {
 				},
 			}
 		}
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
 	})
 
 	server := httptest.NewServer(mux)
@@ -675,7 +675,7 @@ func TestDownloadContainerLogCaching(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		fmt.Fprint(w, logContent)
+		fmt.Fprint(w, logContent) //nolint:errcheck
 	}))
 	defer server.Close()
 
@@ -718,10 +718,10 @@ func TestFetchContainerLogsEndToEnd(t *testing.T) {
 				{Name: "suite/0_kubevirt_virt-controller-abc-virt-controller.log", Size: "100"},
 			},
 		}
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
 	})
 	mux.HandleFunc("/suite/0_kubevirt_virt-controller-abc-virt-controller.log", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, logContent)
+		fmt.Fprint(w, logContent) //nolint:errcheck
 	})
 	mux.HandleFunc("/", notFound)
 

--- a/pkg/ci-failures/k8s_types.go
+++ b/pkg/ci-failures/k8s_types.go
@@ -206,16 +206,16 @@ type ContainerLogFile struct {
 
 // K8sAnalysisResult is the top-level output for analyze-k8s.
 type K8sAnalysisResult struct {
-	ProwJobURL        string               `yaml:"prow_job_url"`
-	JobName           string               `yaml:"job_name"`
-	BuildID           int                  `yaml:"build_id"`
-	Started           time.Time            `yaml:"started"`
-	Finished          time.Time            `yaml:"finished"`
-	Snapshots         []K8sSnapshot        `yaml:"snapshots"`
-	Findings          []*K8sFinding        `yaml:"findings"`
-	Summary           K8sSummary           `yaml:"summary"`
-	EtcdProfile       *EtcdStorageProfile  `yaml:"etcd_profile,omitempty"`
-	ContainerLogFiles []ContainerLogFile   `yaml:"container_log_files,omitempty"`
+	ProwJobURL        string              `yaml:"prow_job_url"`
+	JobName           string              `yaml:"job_name"`
+	BuildID           int                 `yaml:"build_id"`
+	Started           time.Time           `yaml:"started"`
+	Finished          time.Time           `yaml:"finished"`
+	Snapshots         []K8sSnapshot       `yaml:"snapshots"`
+	Findings          []*K8sFinding       `yaml:"findings"`
+	Summary           K8sSummary          `yaml:"summary"`
+	EtcdProfile       *EtcdStorageProfile `yaml:"etcd_profile,omitempty"`
+	ContainerLogFiles []ContainerLogFile  `yaml:"container_log_files,omitempty"`
 }
 
 // EtcdStorageProfile is the top-level structure of etcd-storage-profile.json

--- a/pkg/ci-failures/lane_rate.go
+++ b/pkg/ci-failures/lane_rate.go
@@ -108,7 +108,11 @@ func fetchTestGridTable(dashboard, tab string) (*testGridTableResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch testgrid table: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("testgrid returned status %d for %s", resp.StatusCode, apiURL)
@@ -264,7 +268,11 @@ func WriteLaneRateResultYAML(outputPath string, result *LaneRateResult) error {
 	if err != nil {
 		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(result); err != nil {

--- a/pkg/ci-failures/lane_rate.go
+++ b/pkg/ci-failures/lane_rate.go
@@ -21,15 +21,15 @@ var httpClient = &http.Client{
 }
 
 type testGridTableResponse struct {
-	Timestamps []int64         `json:"timestamps"`
-	Tests      []testGridTest  `json:"tests"`
-	ColumnIDs  []string        `json:"column_ids"`
+	Timestamps []int64        `json:"timestamps"`
+	Tests      []testGridTest `json:"tests"`
+	ColumnIDs  []string       `json:"column_ids"`
 }
 
 type testGridTest struct {
-	Name     string             `json:"name"`
-	Statuses []testGridStatus   `json:"statuses"`
-	Messages []string           `json:"messages"`
+	Name     string           `json:"name"`
+	Statuses []testGridStatus `json:"statuses"`
+	Messages []string         `json:"messages"`
 }
 
 type testGridStatus struct {
@@ -38,9 +38,9 @@ type testGridStatus struct {
 }
 
 const (
-	tgStatusPass    = 1
-	tgStatusFail    = 12
-	tgStatusFlaky   = 3
+	tgStatusPass  = 1
+	tgStatusFail  = 12
+	tgStatusFlaky = 3
 )
 
 type LaneRateResult struct {

--- a/pkg/ci-failures/lane_rate_test.go
+++ b/pkg/ci-failures/lane_rate_test.go
@@ -197,7 +197,7 @@ func TestAnalyzeLaneRate(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(mockResponse)
+		json.NewEncoder(w).Encode(mockResponse) //nolint:errcheck
 	}))
 	defer server.Close()
 

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -37,7 +37,12 @@ func ShowCIFailureJobs() ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open results.json: %v", err)
 	}
-	defer jsonFile.Close()
+	defer func(jsonFile *os.File) {
+		err := jsonFile.Close()
+		if err != nil {
+			log.WithError(err).Warnf("failed to close jsonFile %s", jsonFile.Name())
+		}
+	}(jsonFile)
 
 	byteValue, _ := io.ReadAll(jsonFile)
 

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -19,10 +19,10 @@ const maxDays = 28
 var flakefinderBaseURL = "https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt"
 
 type FlakefinderReport struct {
-	StartOfReport string                            `json:"startOfReport"`
-	EndOfReport   string                            `json:"endOfReport"`
-	Headers       []string                          `json:"headers"`
-	Tests         []string                          `json:"tests"`
+	StartOfReport string                             `json:"startOfReport"`
+	EndOfReport   string                             `json:"endOfReport"`
+	Headers       []string                           `json:"headers"`
+	Tests         []string                           `json:"tests"`
 	Data          map[string]map[string]*TestDetails `json:"data"`
 }
 

--- a/pkg/ci-failures/test_rate.go
+++ b/pkg/ci-failures/test_rate.go
@@ -404,7 +404,11 @@ func WriteTestRateResultYAML(outputPath string, result *TestRateResult) error {
 	if err != nil {
 		return fmt.Errorf("failed to create output file %s: %v", outputPath, err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
 
 	encoder := yaml.NewEncoder(outputFile)
 	if err := encoder.Encode(result); err != nil {

--- a/pkg/ci-failures/test_rate_test.go
+++ b/pkg/ci-failures/test_rate_test.go
@@ -377,7 +377,7 @@ func TestFetchFlakefinderReports(t *testing.T) {
 			expected := fmt.Sprintf("/flakefinder-%s-168h.json", date)
 			if r.URL.Path == expected {
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(report)
+				json.NewEncoder(w).Encode(report) //nolint:errcheck
 				return
 			}
 		}
@@ -418,7 +418,7 @@ func TestFetchFlakefinderReport(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(reportJSON)
+		w.Write(reportJSON) //nolint:errcheck
 	}))
 	defer server.Close()
 

--- a/pkg/ci-failures/test_rate_test.go
+++ b/pkg/ci-failures/test_rate_test.go
@@ -120,9 +120,9 @@ func TestComputeTestRate(t *testing.T) {
 		},
 		Data: map[string]map[string]*TestDetails{
 			"[sig-compute] Live Migrations with a strategy set": {
-				"pull-kubevirt-e2e-k8s-1.35-sig-compute":   {Succeeded: 80, Failed: 10, Skipped: 5},
-				"pull-kubevirt-e2e-k8s-1.36-sig-compute":   {Succeeded: 70, Failed: 20, Skipped: 3},
-				"pull-kubevirt-e2e-kind-1.35-sig-compute":  {Succeeded: 50, Failed: 5, Skipped: 1},
+				"pull-kubevirt-e2e-k8s-1.35-sig-compute":  {Succeeded: 80, Failed: 10, Skipped: 5},
+				"pull-kubevirt-e2e-k8s-1.36-sig-compute":  {Succeeded: 70, Failed: 20, Skipped: 3},
+				"pull-kubevirt-e2e-kind-1.35-sig-compute": {Succeeded: 50, Failed: 5, Skipped: 1},
 			},
 		},
 	}

--- a/pkg/gh/main.go
+++ b/pkg/gh/main.go
@@ -57,10 +57,6 @@ func (rt *retryRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, 
 	return
 }
 
-var (
-	zeroDate = time.Time{}
-)
-
 type Client struct {
 	inner  *githubv4.Client
 	source string

--- a/pkg/gh/main.go
+++ b/pkg/gh/main.go
@@ -3,8 +3,8 @@ package gh
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -67,7 +67,7 @@ type Client struct {
 }
 
 func NewClient(tokenPath string, source string) (*Client, error) {
-	token, err := ioutil.ReadFile(tokenPath)
+	token, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/htmlreport/main.go
+++ b/pkg/htmlreport/main.go
@@ -145,7 +145,11 @@ func fetchJunit(url string) ([]junit.Suite, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch %s: %s", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	// Ignore missing junit files as it suggests an issue with the job
 	if resp.StatusCode == http.StatusNotFound {
@@ -195,7 +199,11 @@ func fetchStartedTime(failureURL string) time.Time {
 		log.Warnf("failed to fetch started.json: %s", err)
 		return time.Time{}
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Warnf("failed to fetch started.json from %s: status code %d", startedURL, resp.StatusCode)
@@ -425,7 +433,11 @@ func Generate(opt *types.Options) error {
 	if err != nil {
 		return fmt.Errorf("could not create report file: %w", err)
 	}
-	defer outputFile.Close()
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing report file")
+		}
+	}()
 
 	err = reportTemplate.Execute(outputFile, reportData)
 	if err != nil {

--- a/pkg/mergequeue/main.go
+++ b/pkg/mergequeue/main.go
@@ -130,16 +130,16 @@ func createMapsFromEvents(pr *types.MergeQueuePullRequestFragment, date time.Tim
 	labelsAdded = make(map[string]time.Time)
 	labelsRemoved = make(map[string]time.Time)
 
-	for _, timelineItem := range pr.TimelineItems.Nodes {
+	for _, timelineItem := range pr.Nodes {
 		if isLabeledEvent(timelineItem, date) {
 
-			labelsAdded[timelineItem.LabeledEventFragment.AddedLabel.Name] = timelineItem.LabeledEventFragment.CreatedAt
-			labelsRemoved[timelineItem.LabeledEventFragment.AddedLabel.Name] = zeroDate
+			labelsAdded[timelineItem.AddedLabel.Name] = timelineItem.LabeledEventFragment.CreatedAt
+			labelsRemoved[timelineItem.AddedLabel.Name] = zeroDate
 
 		} else if isUnlabeledEvent(timelineItem, date) {
 
-			labelsAdded[timelineItem.UnlabeledEventFragment.RemovedLabel.Name] = zeroDate
-			labelsRemoved[timelineItem.UnlabeledEventFragment.RemovedLabel.Name] = timelineItem.UnlabeledEventFragment.CreatedAt
+			labelsAdded[timelineItem.RemovedLabel.Name] = zeroDate
+			labelsRemoved[timelineItem.RemovedLabel.Name] = timelineItem.UnlabeledEventFragment.CreatedAt
 
 		}
 	}
@@ -148,13 +148,13 @@ func createMapsFromEvents(pr *types.MergeQueuePullRequestFragment, date time.Tim
 
 func isLabeledEvent(timelineItem types.TimelineItem, date time.Time) bool {
 	return timelineItem.LabeledEventFragment != types.LabeledEventFragment{} &&
-		timelineItem.LabeledEventFragment.AddedLabel.Name != "" &&
+		timelineItem.AddedLabel.Name != "" &&
 		date.After(timelineItem.LabeledEventFragment.CreatedAt)
 }
 
 func isUnlabeledEvent(timelineItem types.TimelineItem, date time.Time) bool {
 	return timelineItem.UnlabeledEventFragment != types.UnlabeledEventFragment{} &&
-		timelineItem.UnlabeledEventFragment.RemovedLabel.Name != "" &&
+		timelineItem.RemovedLabel.Name != "" &&
 		date.After(timelineItem.UnlabeledEventFragment.CreatedAt)
 }
 
@@ -209,7 +209,7 @@ func firstMapEntryWithKeyMatchingPatternAndNonZeroDate(labelsToTimes map[string]
 
 func hasAllLabelsRequiredForMerge(labelsAdded map[string]time.Time, labelsRemoved map[string]time.Time) bool {
 	for _, requiredForMergeLabel := range constants.RequiredForMergeLabels() {
-		if labelsAdded[requiredForMergeLabel] == zeroDate || labelsRemoved[requiredForMergeLabel] != zeroDate {
+		if labelsAdded[requiredForMergeLabel].Equal(zeroDate) || !labelsRemoved[requiredForMergeLabel].Equal(zeroDate) {
 			return false
 		}
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -116,6 +116,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.MergeQueueLengthName],
 		b.options.MergeQueueLengthLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeBadge(
 		constants.RetestsToMergeBadgeName,
@@ -123,6 +126,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.RetestsToMergeName],
 		b.options.RetestsToMergeLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeBadge(
 		constants.MergedPRsNoRetestBadgeName,
@@ -130,6 +136,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.MergedPRsNoRetest],
 		b.options.MergedPRsNoRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeSIGRetestBadge(
 		constants.SIGComputeBadgeName,
@@ -137,6 +146,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeSIGRetestBadge(
 		constants.SIGStorageBadgeName,
@@ -144,6 +156,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeSIGRetestBadge(
 		constants.SIGNetworkBadgeName,
@@ -151,6 +166,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeSIGRetestBadge(
 		constants.SIGOperatorBadgeName,
@@ -158,6 +176,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeSIGRetestBadge(
 		constants.SIGCIBadgeName,
@@ -165,6 +186,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeSIGRetestBadge(
 		constants.SIGMonitoringBadgeName,
@@ -172,6 +196,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeQuarantineBadge(
 		constants.SIGMonitoringBadgeName,
@@ -179,6 +206,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.QuarantineStats],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeQuarantineBadge(
 		constants.SIGComputeBadgeName,
@@ -186,6 +216,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.QuarantineStats],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeQuarantineBadge(
 		constants.SIGNetworkBadgeName,
@@ -193,6 +226,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.QuarantineStats],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeQuarantineBadge(
 		constants.SIGStorageBadgeName,
@@ -200,6 +236,9 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.QuarantineStats],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = b.writeQuarantineBadge(
 		constants.QuarantineBadgeName,
@@ -207,13 +246,14 @@ func (b *Handler) writeBadges(results *types.Results) error {
 		results.Data[constants.QuarantineStats],
 		b.options.SIGRetestsLevels,
 	)
+	if err != nil {
+		return err
+	}
 
-	err = b.writeJobFailureBadges(
+	return b.writeJobFailureBadges(
 		results.Data[constants.SIGRetests],
 		b.options.SIGRetestsLevels,
 	)
-
-	return err
 }
 
 func (b *Handler) writeBadge(name, filePath string, data types.RunningAverageDataItem, levels *Levels) error {
@@ -320,13 +360,17 @@ func (b *Handler) writeJobFailureBadges(data types.RunningAverageDataItem, level
 				float64(job.FailureCount+job.SuccessCount),
 				(float64(job.FailureCount)/float64(job.FailureCount+job.SuccessCount))*100, "%")
 
-			err = badge.Render(job.JobName, badgeString, color, f)
+			if err := badge.Render(job.JobName, badgeString, color, f); err != nil {
+				return err
+			}
 		} else {
 			color := badge.ColorGreen
-			err = badge.Render("-", "-", color, f)
+			if err := badge.Render("-", "-", color, f); err != nil {
+				return err
+			}
 		}
 	}
-	return err
+	return nil
 }
 
 func (b *Handler) writeQuarantineBadge(name, filePath string, data types.RunningAverageDataItem, levels *Levels) error {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -226,7 +226,11 @@ func (b *Handler) writeBadge(name, filePath string, data types.RunningAverageDat
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Warn("failed closing badge file")
+		}
+	}()
 
 	log.Debugf("Writing color %s", color)
 	badgeString := data.String()
@@ -279,7 +283,11 @@ func (b *Handler) writeSIGRetestBadge(name, filePath string, data types.RunningA
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Warn("failed closing badge file")
+		}
+	}()
 
 	badgeString := fmt.Sprintf("%.0f / %.0f    |    %.2f%s", value, total, percentage, "%")
 
@@ -298,7 +306,11 @@ func (b *Handler) writeJobFailureBadges(data types.RunningAverageDataItem, level
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() {
+			if err := f.Close(); err != nil {
+				log.WithError(err).Warn("failed closing badge file")
+			}
+		}()
 
 		if i < len(failedJobLeaders) {
 			job := failedJobLeaders[i-1]
@@ -339,7 +351,11 @@ func (b *Handler) writeQuarantineBadge(name, filePath string, data types.Running
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Warn("failed closing badge file")
+		}
+	}()
 
 	badgeString := fmt.Sprintf("%.0f", value)
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -3,7 +3,6 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -72,7 +71,7 @@ func (b *Handler) WriteJSON(results *types.Results) error {
 	}
 	log.Infof("Results: %s", string(resultsJSON))
 	resultsPath := filepath.Join(basePath, constants.JSONResultsFileName)
-	err = ioutil.WriteFile(resultsPath, resultsJSON, 0644)
+	err = os.WriteFile(resultsPath, resultsJSON, 0644)
 
 	return err
 }
@@ -89,7 +88,7 @@ func (b *Handler) writeMetrics(results *types.Results) error {
 	log.Debugf("Metrics: %s", m)
 
 	metricsPath := filepath.Join(b.options.Path, constants.MetricsFileName)
-	err := ioutil.WriteFile(metricsPath, []byte(m), 0644)
+	err := os.WriteFile(metricsPath, []byte(m), 0644)
 
 	return err
 }

--- a/pkg/prow/types.go
+++ b/pkg/prow/types.go
@@ -6,7 +6,7 @@ type Started struct {
 	Timestamp int64  `json:"timestamp"`
 	Pull      string `json:"pull"`
 	Repos     struct {
-		repo string `json:"kubevirt/kubevirt"`
+		Repo string `json:"kubevirt/kubevirt"`
 	} `json:"repos"`
 	RepoCommit  string `json:"repo-commit"`
 	RepoVersion string `json:"repo-version"`

--- a/pkg/prow/types_test.go
+++ b/pkg/prow/types_test.go
@@ -2,10 +2,11 @@ package prow
 
 import (
 	"encoding/json"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"os"
 	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestProw(t *testing.T) {

--- a/pkg/quarantine/main.go
+++ b/pkg/quarantine/main.go
@@ -41,7 +41,7 @@ func quarantineReportURL(org string, repo string) string {
 
 func httpGetWithRetry(url string) (resp *http.Response, err error) {
 	httpRetryLog := log.WithField("url", url)
-	retry.Do(
+	err = retry.Do(
 		func() error {
 			resp, err = http.Get(url)
 			switch {
@@ -75,7 +75,11 @@ func GetQuarantineStats() (stats QuarantineStats, err error) {
 		log.Errorf("Failed to download quarantine report")
 		return qStats, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(&quarantineReport)

--- a/pkg/runner/batch.go
+++ b/pkg/runner/batch.go
@@ -204,7 +204,11 @@ func gatherPlotData(basePath string, metric types.Metric, startDate string) ([]t
 		if err != nil {
 			return err
 		}
-		defer jsonFile.Close()
+		defer func() {
+			if err := jsonFile.Close(); err != nil {
+				log.WithError(err).Warn("failed closing json file")
+			}
+		}()
 		byteValue, err := ioutil.ReadAll(jsonFile)
 		if err != nil {
 			return err

--- a/pkg/runner/batch.go
+++ b/pkg/runner/batch.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image/color"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -46,10 +46,7 @@ func batchFetchRun(o *types.Options, mqHandler *mergequeue.Handler, coHandler *c
 
 	outputOptions := &output.Options{}
 
-	for {
-		if now.Before(currentEndDate) {
-			break
-		}
+	for !now.Before(currentEndDate) {
 
 		// write results file
 		baseDataPath := batchDataPath(o.Path, o.Source, string(o.TargetMetric))
@@ -209,7 +206,7 @@ func gatherPlotData(basePath string, metric types.Metric, startDate string) ([]t
 				log.WithError(err).Warn("failed closing json file")
 			}
 		}()
-		byteValue, err := ioutil.ReadAll(jsonFile)
+		byteValue, err := io.ReadAll(jsonFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -26,7 +25,7 @@ func Run(o *types.Options) (*types.Results, error) {
 	}
 
 	if o.TokenPath == "" {
-		return nil, fmt.Errorf("You need to specify the GitHub token path with --gh-token")
+		return nil, fmt.Errorf("you need to specify the GitHub token path with --gh-token")
 	}
 
 	ghClient, err := gh.NewClient(o.TokenPath, o.Source)
@@ -43,7 +42,7 @@ func Run(o *types.Options) (*types.Results, error) {
 	case types.BatchAction:
 		return batchRun(o, mqHandler, coHandler)
 	default:
-		return nil, fmt.Errorf("Unknown action: %q", o.Action)
+		return nil, fmt.Errorf("unknown action: %q", o.Action)
 	}
 }
 
@@ -80,7 +79,7 @@ func statsRun(o *types.Options, mqHandler *mergequeue.Handler, coHandler *chatop
 	}
 
 	if o.Path == "" {
-		dir, err := ioutil.TempDir("", "ci-health")
+		dir, err := os.MkdirTemp("", "ci-health")
 		if err != nil {
 			return nil, err
 		}
@@ -139,7 +138,7 @@ func batchRun(o *types.Options, mqHandler *mergequeue.Handler, coHandler *chatop
 	case types.PlotMode:
 		return batchPlotRun(o)
 	default:
-		return nil, fmt.Errorf("Unknown batch mode: %q", o.Mode)
+		return nil, fmt.Errorf("unknown batch mode: %q", o.Mode)
 	}
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -141,11 +141,3 @@ func batchRun(o *types.Options, mqHandler *mergequeue.Handler, coHandler *chatop
 		return nil, fmt.Errorf("unknown batch mode: %q", o.Mode)
 	}
 }
-
-func setLogLevel(logLevel string) {
-	if logLevel == "debug" {
-		log.SetLevel(log.DebugLevel)
-	} else {
-		log.SetLevel(log.InfoLevel)
-	}
-}

--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -140,7 +140,7 @@ func filterForLastCommit(storageBaseURL string, org string, repo string, prNumbe
 	for _, job := range jobList {
 		finishedJSON, err := http.Get(finishedJSONURL(storageBaseURL, org, repo, prNumber, job.jobName, job.buildNumber))
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get %s finished.json : %s", job.jobName, err)
+			return nil, fmt.Errorf("failed to get %s finished.json : %s", job.jobName, err)
 		}
 		defer func() {
 			if err := finishedJSON.Body.Close(); err != nil {
@@ -153,12 +153,12 @@ func filterForLastCommit(storageBaseURL string, org string, repo string, prNumbe
 
 		finishedJSONData, err := io.ReadAll(finishedJSON.Body)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to read finished JSON for %s -- %s", job.jobName, err)
+			return nil, fmt.Errorf("failed to read finished JSON for %s -- %s", job.jobName, err)
 		}
 		var data map[string]interface{}
 		err = json.Unmarshal(finishedJSONData, &data)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to unmarshall finished JSON for %s -- %s", job.jobName, err)
+			return nil, fmt.Errorf("failed to unmarshall finished JSON for %s -- %s", job.jobName, err)
 		}
 		if latestCommit != data["revision"] {
 			continue
@@ -240,11 +240,11 @@ func getJobsForLatestCommit(storageBaseURL string, org string, repo string, prNu
 
 	prHistoryPage, err := html.Parse(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing history page: %s", err)
+		return nil, fmt.Errorf("error parsing history page: %s", err)
 	}
 	latestCommit := getLatestCommit(prHistoryPage)
 	if latestCommit == "" {
-		return nil, fmt.Errorf("Failed to get latest commit from %s", prHistory)
+		return nil, fmt.Errorf("failed to get latest commit from %s", prHistory)
 	}
 	jobsAllCommits := filterJobs(prHistoryPage)
 	prowjobs = nil
@@ -295,7 +295,7 @@ func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response,
 }
 
 func sortJobNamesOnResult(job job, sigRetests SigRetests) (jobCounts SigRetests) {
-	if job.failure == true {
+	if job.failure {
 		sigRetests.FailedJobNames = append(sigRetests.FailedJobNames, job.jobName)
 		sigRetests.FailedJobURLs = append(sigRetests.FailedJobURLs, job.buildURL)
 	} else {
@@ -307,7 +307,7 @@ func sortJobNamesOnResult(job job, sigRetests SigRetests) (jobCounts SigRetests)
 func GetJobsPerSIG(prNumber string, org string, repo string, supportedBranches []string, notBefore time.Time) (prSigRetests SigRetests, err error) {
 	prowJobs, err := getJobsForLatestCommit(defaultStorageBaseURL, org, repo, prNumber, notBefore)
 	if err != nil {
-		return SigRetests{}, fmt.Errorf("Error filtering failed jobs from the latest commit - %s", err)
+		return SigRetests{}, fmt.Errorf("error filtering failed jobs from the latest commit - %s", err)
 	}
 	return FilterJobsPerSigs(prowJobs, supportedBranches), nil
 }

--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -142,7 +142,11 @@ func filterForLastCommit(storageBaseURL string, org string, repo string, prNumbe
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get %s finished.json : %s", job.jobName, err)
 		}
-		defer finishedJSON.Body.Close()
+		defer func() {
+			if err := finishedJSON.Body.Close(); err != nil {
+				log.WithError(err).Warn("failed closing response body")
+			}
+		}()
 		if finishedJSON.StatusCode != http.StatusOK {
 			continue
 		}
@@ -190,7 +194,11 @@ func filterOptionalJobs(org, repo, prNumber string, unfilteredJobs []job) ([]job
 		if err != nil {
 			return nil, err
 		}
-		defer prowJobJSON.Body.Close()
+		defer func() {
+			if err := prowJobJSON.Body.Close(); err != nil {
+				log.WithError(err).Warn("failed closing response body")
+			}
+		}()
 		if prowJobJSON.StatusCode != 200 {
 			continue
 		}
@@ -224,7 +232,11 @@ func getJobsForLatestCommit(storageBaseURL string, org string, repo string, prNu
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	prHistoryPage, err := html.Parse(resp.Body)
 	if err != nil {
@@ -260,7 +272,7 @@ func HttpHeadWithRetry(url string) (resp *http.Response, err error) {
 
 func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response, err error)) (resp *http.Response, err error) {
 	httpRetryLog := log.WithField("url", url).WithField("verb", runtime.FuncForPC(reflect.ValueOf(httpVerb).Pointer()).Name())
-	retry.Do(
+	err = retry.Do(
 		func() error {
 			resp, err = httpVerb(url)
 			switch {
@@ -362,7 +374,11 @@ func ListPRFailures(prNumber, prOrg, prRepo string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("failed closing response body")
+		}
+	}()
 
 	prHistoryPage, err := html.Parse(resp.Body)
 	if err != nil {

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -87,11 +87,11 @@ var _ = Describe("main", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case strings.HasSuffix(r.URL.Path, "/job-old/100/finished.json"):
-					fmt.Fprintf(w, `{"timestamp": %d, "revision": "%s", "result": "FAILURE"}`, oldTimestamp, testCommit)
+					fmt.Fprintf(w, `{"timestamp": %d, "revision": "%s", "result": "FAILURE"}`, oldTimestamp, testCommit) //nolint:errcheck
 				case strings.HasSuffix(r.URL.Path, "/job-recent/200/finished.json"):
-					fmt.Fprintf(w, `{"timestamp": %d, "revision": "%s", "result": "FAILURE"}`, recentTimestamp, testCommit)
+					fmt.Fprintf(w, `{"timestamp": %d, "revision": "%s", "result": "FAILURE"}`, recentTimestamp, testCommit) //nolint:errcheck
 				case strings.HasSuffix(r.URL.Path, "/job-no-timestamp/300/finished.json"):
-					fmt.Fprintf(w, `{"revision": "%s", "result": "SUCCESS"}`, testCommit)
+					fmt.Fprintf(w, `{"revision": "%s", "result": "SUCCESS"}`, testCommit) //nolint:errcheck
 				default:
 					http.NotFound(w, r)
 				}

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -79,7 +79,7 @@ func (h *Handler) Run() (*types.Results, error) {
 		case types.QuarantineMetric:
 			processor = h.quarantineProcessor
 		default:
-			return nil, fmt.Errorf("Unknown metric: %q", targetMetric)
+			return nil, fmt.Errorf("unknown metric: %q", targetMetric)
 		}
 
 		results, err = processor(results)
@@ -379,7 +379,7 @@ func Std(xs []float64) float64 {
 	avg := Average(xs)
 	total := 0.0
 	for _, v := range xs {
-		total += math.Pow((v - avg), 2)
+		total += (v - avg) * (v - avg)
 	}
 	variance := total / float64(len(xs))
 	result := math.Sqrt(variance)

--- a/pkg/timeutils/main.go
+++ b/pkg/timeutils/main.go
@@ -10,14 +10,10 @@ func ClosestMonday(date string) (time.Time, error) {
 	currentDate, err := time.Parse(layout, date)
 
 	if err != nil {
-		return time.Time{}, fmt.Errorf("Not a valid date: %q", date)
+		return time.Time{}, fmt.Errorf("not a valid date: %q", date)
 	}
 
-	for {
-		if currentDate.Weekday().String() == "Monday" {
-			break
-		}
-
+	for currentDate.Weekday() != time.Monday {
 		currentDate = currentDate.AddDate(0, 0, 1)
 	}
 

--- a/pkg/timeutils/timeutils_test.go
+++ b/pkg/timeutils/timeutils_test.go
@@ -33,7 +33,7 @@ var _ = Describe("ClosestMonday", func() {
 		table.Entry("invalid date",
 			"not a valid date",
 			time.Time{},
-			fmt.Errorf("Not a valid date: %q", "not a valid date"),
+			fmt.Errorf("not a valid date: %q", "not a valid date"),
 		),
 		table.Entry("valid date, monday",
 			"2021-05-03",

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -33,7 +33,7 @@ func (m Metric) IsValid() error {
 	case MergeQueueLengthMetric, TimeToMergeMetric, RetestsToMergeMetric, MergedPRsMetric, QuarantineMetric:
 		return nil
 	}
-	return errors.New("Invalid MetricType value")
+	return errors.New("invalid MetricType value")
 }
 
 func (m Metric) ResultsName() string {
@@ -60,7 +60,7 @@ func (a Action) IsValid() error {
 	case StatsAction, BatchAction:
 		return nil
 	}
-	return errors.New("Invalid Action value")
+	return errors.New("invalid Action value")
 }
 
 type Mode string
@@ -70,7 +70,7 @@ func (m Mode) IsValid() error {
 	case FetchMode, PlotMode:
 		return nil
 	}
-	return errors.New("Invalid BatchMode value")
+	return errors.New("invalid BatchMode value")
 }
 
 type Options struct {


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` with "chill" profile and non-blocking reviews
- Add `.golangci.yml` (v2) with all standard linters enabled
- Fix all linter warnings across the codebase: errcheck (defer Close patterns), govet (struct tags), ineffassign, staticcheck (deprecated APIs, error string conventions, embedded field simplification), and unused code removal

This PR is a prerequisite of replacing Gemini Code Assist ([which will be sunset](https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review)) with Coderabbit

## Test plan

- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` passes for all affected packages
- [ ] CodeRabbit activates on the repo after merge

🤖 Assisted by Claude