### PR TITLE
fix: handle HTTP 404 as valid response in DoHTTPWithRetry

### DIFF
--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -282,6 +282,9 @@ func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response,
 			case resp.StatusCode == http.StatusOK:
 				httpRetryLog.Debugf("succeeded")
 				return nil
+			case resp.StatusCode == http.StatusNotFound:
+				httpRetryLog.Debugf("not found")
+				return nil
 			case resp.StatusCode == http.StatusGatewayTimeout:
 				httpRetryLog.Infof("failed with %d, will retry", resp.StatusCode)
 				return fmt.Errorf("failed with %d: %v", resp.StatusCode, err)

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -67,6 +67,43 @@ var _ = Describe("main", func() {
 		})
 	})
 
+	Context("DoHTTPWithRetry", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("returns nil error for 200 OK", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			resp, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("returns nil error for 404 Not Found", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			resp, err := DoHTTPWithRetry(server.URL, http.Head)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns error for 403 Forbidden", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			}))
+			_, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("status 403"))
+		})
+	})
+
 	Context("filterForLastCommit time filtering", func() {
 		var server *httptest.Server
 		var testCommit string


### PR DESCRIPTION
## Summary

- `DoHTTPWithRetry` treated all non-200/non-504 HTTP status codes as unrecoverable errors, including 404
- This caused `checkJunitFuncTestXMLExists` to fatally abort when a junit artifact returned 404, instead of gracefully reporting it as non-existent
- Fix: treat 404 (Not Found) as a valid response, allowing callers to inspect the status code

Fixes the `summary-update` GitHub Action failure: https://github.com/kubevirt/ci-health/actions/runs/27016574970/job/79733039991

## Test plan

- [x] `golangci-lint run ./...` passes
- [x] `go test ./pkg/sigretests/ ./pkg/ci-failures/` passes
- [ ] `summary-update` GitHub Action succeeds after merge

🤖 Assisted by Claude