### PR TITLE
Sort FailureURLs by job date (newest first)

### DIFF
--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"cmp"
 	"fmt"
 	"math"
 	"slices"
@@ -318,11 +319,21 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 				sortedFailedJobs[i].FailureURLs = append(sortedFailedJobs[i].FailureURLs, failedJobURL)
 			}
 		}
+		// Sort by Prow job ID descending (newest first)
+		slices.SortFunc(sortedFailedJobs[i].FailureURLs, func(a, b string) int {
+			return cmp.Compare(prowJobID(b), prowJobID(a))
+		})
 	}
 	dataItem.FailedJobLeaderBoard = sortedFailedJobs
 	results.Data[constants.SIGRetests] = dataItem
 
 	return results, nil
+}
+
+func prowJobID(url string) int {
+	parts := strings.Split(url, "/")
+	id, _ := strconv.Atoi(parts[len(parts)-1])
+	return id
 }
 
 func (h *Handler) quarantineProcessor(results *types.Results) (*types.Results, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prow job IDs are Snowflake-style and encode timestamps,
so sorting by job ID descending orders from recent to oldest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure URLs in SIG retest leaderboards are now sorted by job ID in descending order, making results more consistent and easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->