### PR TITLE
feat: add flake overview reports

### DIFF
--- a/output/kubevirt/kubevirt/flake-overview/flake-overview-2026-06-22.md
+++ b/output/kubevirt/kubevirt/flake-overview/flake-overview-2026-06-22.md
@@ -1,0 +1,492 @@
+# Flake Overview Report — 2026-06-22
+
+## Summary
+
+| Metric | 28-day | 7-day | Trend |
+|--------|--------|-------|-------|
+| Total failures | 1903 | 598 | Worsening (7d projects to ~2392/28d) |
+| Lanes with failures | 47 | 32 | — |
+| Analysis window | May 25 – Jun 22 | Jun 15 – Jun 22 | — |
+
+**Overall trend: Worsening.** The 7-day failure count (598) projects to ~2392 over 28 days, exceeding the actual 28-day total (1903) by ~26%. The recent week is disproportionately noisy.
+
+**Top 3 worst SIGs by failure count (28d):**
+1. **sig-compute** — 1148 failures (60.3%) across periodic + presubmit lanes
+2. **sig-storage** — 303 failures (15.9%)
+3. **sig-network** — 149 failures (7.8%)
+
+**Quarantine candidates identified:** 3 high priority, 3 medium priority, 1 low priority
+
+**Infra-unstable lanes:** Pod-level failures affect nearly every lane, with presubmit lanes particularly bad (52–77% Pod success rates)
+
+## Navigation
+
+- [Infrastructure](#infrastructure)
+- [sig-compute](#sig-compute)
+- [sig-storage](#sig-storage)
+- [sig-network](#sig-network)
+- [sig-operator](#sig-operator)
+- [sig-monitoring](#sig-monitoring)
+- [sig-performance](#sig-performance)
+- [Platform-specific](#platform-specific)
+- [Quarantine Candidate Summary](#quarantine-candidate-summary)
+
+---
+
+## Infrastructure
+
+Pod-level failures represent infrastructure instability (cluster provisioning, setup failures) rather than test code issues. These should **not** be addressed by quarantining individual tests.
+
+### Presubmit Pod Failure Rates (28d)
+
+| Lane | Pod Success Rate (28d) | Pod Success Rate (7d) | Trend |
+|------|------------------------|-----------------------|-------|
+| pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations | 52.6% | 76.0% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-network | 63.6% | 72.3% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-storage | 64.5% | 75.7% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute | 65.9% | 76.4% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-operator | 65.3% | 73.9% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute-serial | 65.4% | 74.6% | Improving |
+| pull-kubevirt-e2e-kind-1.35-sig-compute-arm64 | 71.6% | 85.0% | Improving |
+| pull-kubevirt-e2e-k8s-1.35-sig-storage | 72.0% | 93.2% | Improving |
+| pull-kubevirt-e2e-k8s-1.35-sig-operator | 73.3% | n/a | — |
+| pull-kubevirt-e2e-k8s-1.34-sig-network | 73.5% | 91.3% | Improving |
+| pull-kubevirt-e2e-k8s-1.34-sig-compute | 73.7% | n/a | — |
+| pull-kubevirt-e2e-k8s-1.35-sig-network | 74.1% | n/a | — |
+| pull-kubevirt-e2e-kind-sriov | 74.5% | n/a | — |
+| pull-kubevirt-e2e-k8s-1.34-sig-storage | 74.9% | 94.9% | Improving |
+| pull-kubevirt-e2e-k8s-1.34-sig-operator | 75.4% | n/a | — |
+| pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network | 76.0% | n/a | — |
+| pull-kubevirt-e2e-k8s-1.34-windows2016 | 77.5% | n/a | — |
+| pull-kubevirt-check-tests-for-flakes | 78.1% | 85.2% | Improving |
+| pull-kubevirt-e2e-kind-1.35-vgpu | 78.4% | n/a | — |
+
+**Key observation:** Pod failure rates in presubmit lanes are **improving** in the 7d window vs 28d, particularly for k8s-1.36 lanes and 1.35-sig-storage. However, k8s-1.36 lanes still have the worst rates overall (65–76% success).
+
+### Periodic Pod Failure Rates (28d)
+
+| Lane | Pod Success Rate (28d) | Pod Success Rate (7d) | Trend |
+|------|------------------------|-----------------------|-------|
+| periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations | 64.7% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc | 81.3% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network | 80.6% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-storage | 85.0% | 87.5% | Stable |
+| periodic-kubevirt-e2e-k8s-1.34-sig-compute | 86.6% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-performance | 86.7% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-storage | 86.9% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-network | 86.9% | 93.8% | Improving |
+| periodic-kubevirt-e2e-k8s-1.34-sig-network | 86.9% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-compute | 87.5% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok | 87.5% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-operator | 87.8% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-compute | 87.9% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-network | 87.9% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-operator | 87.9% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-storage | 87.9% | n/a | — |
+| periodic-kubevirt-e2e-test-S390X | 88.0% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-monitoring | 88.0% | n/a | — |
+| periodic-kubevirt-e2e-kind-1.34-sev | 88.0% | n/a | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-operator | 88.7% | n/a | — |
+
+### AfterSuite Failures
+
+AfterSuite failures indicate test framework teardown issues:
+
+| Lane | AfterSuite Success Rate (28d) | 7d |
+|------|-------------------------------|----|
+| pull-kubevirt-e2e-k8s-1.35-sig-operator | 0% (2/2 runs) | 0% (2/2) |
+| pull-kubevirt-e2e-k8s-1.35-sig-storage | 0% (2/2 runs) | 0% (2/2) |
+| pull-kubevirt-e2e-k8s-1.34-sig-operator | 0% (1/1 runs) | n/a |
+
+These are very low-sample entries and likely represent individual bad builds rather than persistent issues.
+
+---
+
+## sig-compute
+
+**28d total failures: 1148** (60.3% of all failures)
+**7d total failures: 384** (64.2% of all failures)
+**Trend: Worsening** — sig-compute's share of failures is growing
+
+### Periodic Lanes
+
+#### [periodic-kubevirt-e2e-k8s-1.34-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-compute)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 421 | 22.12% | 97 | 75 | 12.54% | Stable |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [Should successfully passthrough 2 emulated PCI devices](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L112) | 0% | 0% | Stable | Concentrated (1 lane) | Consecutive — deterministic breakage |
+| [Should successfully passthrough an emulated PCI device](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L111) | 0% | 0% | Stable | Concentrated (1 lane + serial) | Consecutive — deterministic breakage |
+| [USB] [QUARANTINE] Should successfully passthrough 1 emulated USB device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) `[QUARANTINE]` | 0% | 0% | Stable | Dispersed (3 lanes) | Consecutive — deterministic breakage |
+| [[QUARANTINE] Should successfully passthrough 2 emulated USB devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) `[QUARANTINE]` | 0% | 0% | Stable | Dispersed (3 lanes) | Consecutive — deterministic breakage |
+| [[QUARANTINE] Guest console log flood serial console](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) `[QUARANTINE]` | 85.3% | 92.9% | Improving | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] ClusterProfiler subresource access](https://github.com/kubevirt/kubevirt/blob/main/tests/infrastructure/cluster-profiler.go#L62) `[QUARANTINE]` | n/a (28d) | 92.9% | — | Concentrated (2 lanes) | Flaky |
+
+**Analysis:** The emulated PCI device tests (0% success, k8s-1.34 only) are **deterministic breakage** on this lane, not flakes. The k8s-1.34 environment likely lacks the required device emulation support. USB passthrough tests are similarly broken at 0% here but show 52–58% on k8s-1.35/1.36, indicating a genuine flake on newer versions but complete breakage on k8s-1.34.
+
+#### [periodic-kubevirt-e2e-k8s-1.35-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-compute)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 122 | 6.41% | 97 | 47 | 7.86% | Worsening |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) `[QUARANTINE]` | 52.8% | 15.4% | Worsening | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) `[QUARANTINE]` | 52.8% | 15.4% | Worsening | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) `[QUARANTINE]` | 87.6% | 84.6% | Stable | Dispersed (3 lanes) | Flaky |
+
+#### [periodic-kubevirt-e2e-k8s-1.36-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 159 | 8.36% | 99 | 34 | 5.69% | Improving |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) `[QUARANTINE]` | 58.3% | 56.3% | Stable | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) `[QUARANTINE]` | 58.3% | 56.3% | Stable | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) `[QUARANTINE]` | 85.4% | 81.3% | Stable | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] ClusterProfiler subresource access](https://github.com/kubevirt/kubevirt/blob/main/tests/infrastructure/cluster-profiler.go#L62) `[QUARANTINE]` | 92.7% | 93.8% | Stable | Concentrated (2 lanes) | Flaky |
+
+#### [periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 53 | 2.79% | 35 | 48 | 8.03% | Worsening significantly |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L650) `[QUARANTINE]` | 70.0% | 30.8% | Worsening | Dispersed (4+ lanes) | Flaky — high flip rate |
+| [[QUARANTINE] Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L651) `[QUARANTINE]` | 70.0% | 30.8% | Worsening | Dispersed (4+ lanes) | Flaky — high flip rate |
+| [Post-copy migration with liveness probe](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/postcopy.go#L176) | 88.5% | 92.3% | Stable | Concentrated (1 lane) | Flaky |
+| [Evacuation backoff should be cleared](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/evacuation.go#L185) | 93.3% | n/a | — | Concentrated (1 lane) | Flaky |
+
+### Presubmit Lanes (sig-compute)
+
+| Lane | Failures (28d) | Pod Rate (28d) | Pod Rate (7d) | Trend |
+|------|----------------|----------------|---------------|-------|
+| [pull-kubevirt-e2e-k8s-1.36-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute) | 84 | 65.9% | 76.4% | Improving |
+| [pull-kubevirt-e2e-k8s-1.36-sig-compute-serial](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute-serial) | 7 | 65.4% | 74.6% | Improving |
+| [pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations) | 29 | 52.6% | 76.0% | Improving |
+| [pull-kubevirt-e2e-k8s-1.35-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-compute) | 13 | 74.0% | n/a | — |
+| [pull-kubevirt-e2e-k8s-1.34-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-compute) | 9 | 73.7% | n/a | — |
+
+Presubmit sig-compute failures are almost entirely Pod-level (infra). Actual test failures in presubmit lanes are minimal.
+
+---
+
+## sig-storage
+
+**28d total failures: 303** (15.9% of all failures)
+**7d total failures: 142** (23.7% of all failures)
+**Trend: Worsening significantly** — sig-storage's share nearly doubled in the last 7 days
+
+### Periodic Lanes
+
+#### [periodic-kubevirt-e2e-k8s-1.34-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-storage)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 96 | 5.04% | 99 | 48 | 8.03% | Worsening |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] Should pause VMI on IO error](https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L167) `[QUARANTINE]` | 48.9% | 87.5% | Improving | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L650) `[QUARANTINE]` | 87.2% | 25.0% | Worsening | Dispersed (4+ lanes) | Flaky — recent regression |
+| [[QUARANTINE] Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L651) `[QUARANTINE]` | 87.2% | 25.0% | Worsening | Dispersed (4+ lanes) | Flaky — recent regression |
+
+#### [periodic-kubevirt-e2e-k8s-1.35-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-storage)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 85 | 4.47% | 100 | 44 | 7.36% | Worsening |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] Should pause VMI on IO error](https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L167) `[QUARANTINE]` | 55.2% | 93.8% | Improving | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L650) `[QUARANTINE]` | 87.5% | 31.3% | Worsening | Dispersed (4+ lanes) | Flaky — recent regression |
+| [[QUARANTINE] Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L651) `[QUARANTINE]` | 88.5% | 31.3% | Worsening | Dispersed (4+ lanes) | Flaky — recent regression |
+
+#### [periodic-kubevirt-e2e-k8s-1.36-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 92 | 4.83% | 100 | 43 | 7.19% | Worsening |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] Should pause VMI on IO error](https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L167) `[QUARANTINE]` | 52.1% | 92.9% | Improving | Dispersed (3 lanes) | Flaky |
+| [[QUARANTINE] Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L650) `[QUARANTINE]` | 89.4% | 28.6% | Worsening | Dispersed (4+ lanes) | Flaky — recent regression |
+| [[QUARANTINE] Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L651) `[QUARANTINE]` | 89.4% | 28.6% | Worsening | Dispersed (4+ lanes) | Flaky — recent regression |
+
+### Presubmit Lanes (sig-storage)
+
+| Lane | Failures (28d) | Pod Rate (28d) | Pod Rate (7d) | Trend |
+|------|----------------|----------------|---------------|-------|
+| [pull-kubevirt-e2e-k8s-1.36-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-storage) | 18 | 64.5% | 75.7% | Improving |
+| [pull-kubevirt-e2e-k8s-1.34-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-storage) | 7 | 74.9% | 94.9% | Improving |
+| [pull-kubevirt-e2e-k8s-1.35-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-storage) | 5 | 72.0% | 93.2% | Improving |
+
+---
+
+## sig-network
+
+**28d total failures: 149** (7.8% of all failures)
+**7d total failures: 37** (6.2% of all failures)
+**Trend: Improving** — sig-network's share is decreasing
+
+### Periodic Lanes
+
+#### [periodic-kubevirt-e2e-k8s-1.35-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-network)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 24 | 1.26% | 100 | 5 | 0.84% | Improving |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [Passt migration connectivity ipv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) | 82.4% | 81.8% | Stable | Dispersed (3+ lanes) | Flaky |
+| [NIC hotplug migrate VMI](https://github.com/kubevirt/kubevirt/blob/main/tests/network/hotplug_bridge.go#L145) | n/a | 93.3% | — | Concentrated (1 lane) | Flaky |
+
+#### [periodic-kubevirt-e2e-k8s-1.36-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-network)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 21 | 1.10% | 99 | 8 | 1.34% | Stable |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] Passt migration connectivity ipv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) `[QUARANTINE]` | 80.0% | 80.0% | Stable | Dispersed (3+ lanes) | Flaky |
+| [Passt migration connectivity ipv4 (non-quarantine)](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) | 92.4% | 90.9% | Stable | Dispersed (3+ lanes) | Flaky |
+
+#### [periodic-kubevirt-e2e-k8s-1.34-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-network)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 8 | 0.42% | 99 | 3 | 0.50% | Stable |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [[QUARANTINE] Passt migration connectivity ipv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) `[QUARANTINE]` | 80.0% | 80.0% | Stable | Dispersed (3+ lanes) | Flaky |
+| [Passt migration connectivity ipv4 (non-quarantine)](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) | 92.4% | 90.9% | Stable | Dispersed (3+ lanes) | Flaky |
+
+#### [periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc)
+
+| Failures (28d) | Share | Builds |
+|-----------------|-------|--------|
+| 3 | 0.16% | 16 |
+
+| Test | Success Rate (28d) | Dispersion | Pattern |
+|------|---------------------|------------|---------|
+| [NIC hotplug multiple interfaces](https://github.com/kubevirt/kubevirt/blob/main/tests/network/hotplug_bridge.go#L145) | 87.5% | Concentrated (1 lane) | Flaky |
+| [Passt migration connectivity ipv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) | 93.3% | Dispersed (3+ lanes) | Flaky |
+
+### Presubmit Lanes (sig-network)
+
+| Lane | Failures (28d) | Pod Rate (28d) | Pod Rate (7d) | Trend |
+|------|----------------|----------------|---------------|-------|
+| [pull-kubevirt-e2e-k8s-1.36-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-network) | 23 | 63.6% | 72.3% | Improving |
+| [pull-kubevirt-e2e-k8s-1.35-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-network) | 32 | 74.1% | n/a | — |
+| [pull-kubevirt-e2e-k8s-1.34-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-network) | 27 | 73.5% | 91.3% | Improving |
+| [pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network) | 10 | 76.0% | n/a | — |
+
+---
+
+## sig-operator
+
+**28d total failures: 161** (8.5% of all failures)
+**7d total failures: 91** (15.2% of all failures)
+**Trend: Worsening** — sig-operator's share nearly doubled
+
+### Periodic Lanes
+
+#### [periodic-kubevirt-e2e-k8s-1.34-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-operator)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 45 | 2.36% | 97 | 44 | 7.36% | Worsening significantly |
+
+No failing tests reported (28d only has Pod failures). The 7d spike to 44 failures with only 14 builds and no test details suggests a cluster-level outage or infra issue during this period.
+
+#### [periodic-kubevirt-e2e-k8s-1.35-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-operator)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 3 | 0.16% | 98 | 1 | 0.17% | Stable |
+
+#### [periodic-kubevirt-e2e-k8s-1.36-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-operator)
+
+| Failures (28d) | Share | Builds | 7d Failures |
+|-----------------|-------|--------|-------------|
+| 2 | 0.11% | 99 | n/a |
+
+### Presubmit Lanes (sig-operator)
+
+| Lane | Failures (28d) | Pod Rate (28d) | Pod Rate (7d) | Trend |
+|------|----------------|----------------|---------------|-------|
+| [pull-kubevirt-e2e-k8s-1.35-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-operator) | 60 | 73.3% | n/a | — |
+| [pull-kubevirt-e2e-k8s-1.36-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-operator) | 50 | 65.3% | 73.9% | Improving |
+| [pull-kubevirt-e2e-k8s-1.34-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-operator) | 1 | 75.4% | n/a | — |
+
+Notable presubmit test:
+| Test | Success Rate (7d) | Lane |
+|------|-------------------|------|
+| [Should be able to delete and re-create kubevirt install](https://github.com/kubevirt/kubevirt/blob/main/tests/operator/operator.go#L1032) | 95.0% | pull-kubevirt-e2e-k8s-1.36-sig-operator |
+
+---
+
+## sig-monitoring
+
+**28d total failures: 54** (2.8% of all failures)
+**7d total failures: 24** (4.0% of all failures)
+**Trend: Worsening** — sig-monitoring share increased
+
+### [periodic-kubevirt-e2e-k8s-1.34-sig-monitoring](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-monitoring)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 53 | 2.79% | 50 | 24 | 4.01% | Worsening |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [Should contain virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | 75.0% | 0% | Worsening | Concentrated (1 periodic + 1 presubmit) | Recent regression? |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) | 75.0% | 28.6% | Worsening | Concentrated (1 periodic + 1 presubmit) | Recent regression? |
+| [[QUARANTINE] VM dirty rate metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/vm_monitoring.go#L334) `[QUARANTINE]` | 89.6% | n/a | — | Concentrated (1 lane) | Flaky |
+
+### [pull-kubevirt-e2e-k8s-1.34-sig-monitoring](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-monitoring)
+
+| Test | Success Rate (28d) | Severity |
+|------|---------------------|----------|
+| [Should contain virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | 30.8% | likely-flaky |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) | 28.1% | likely-flaky |
+| [Should have all required annotations](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | 87.2% | inconclusive |
+
+**Analysis:** The monitoring tests "virt components metrics" and "VirtOperatorRESTErrorsBurst" are severely broken in the presubmit lane (28–31% success) and getting worse in periodics (7d: 0% and 28.6%). This looks like a recent regression rather than long-standing flakiness.
+
+---
+
+## sig-performance
+
+**28d total failures: 8** (0.4% of all failures)
+**7d total failures: 0**
+**Trend: Stable/Minimal**
+
+### [periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok)
+
+| Failures (28d) | Share | Builds |
+|-----------------|-------|--------|
+| 5 | 0.26% | 72 |
+
+Pod-level failures only (87.5% success rate). No test-level issues.
+
+### [periodic-kubevirt-e2e-k8s-1.34-sig-performance](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance)
+
+| Failures (28d) | Share | Builds |
+|-----------------|-------|--------|
+| 3 | 0.16% | 75 |
+
+Pod-level failures only (86.7% success rate). No test-level issues.
+
+---
+
+## Platform-specific
+
+### [periodic-kubevirt-e2e-test-S390X](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-test-S390X)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 209 | 10.98% | 100 | 39 | 6.52% | Improving |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Trend | Dispersion | Pattern |
+|------|--------------------|--------------------|-------|------------|---------|
+| [Should block eviction api and migrate](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/eviction_strategy.go#L520) | 45.9% | 37.5% | Worsening | Concentrated (S390X only) | Flaky — high flip rate |
+| [Migrate multiple times with cloud-init](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L551) | 80.6% | 75.0% | Worsening | Concentrated (S390X only) | Flaky |
+| [Should migrate even if virtqemud restarted](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L589) | 92.9% | 93.8% | Stable | Concentrated (S390X only) | Flaky |
+| [CPU hotplug — plug vCPUs](https://github.com/kubevirt/kubevirt/blob/main/tests/hotplug/cpu.go#L106) | n/a | 87.5% | — | Concentrated (S390X only) | Flaky |
+
+**Analysis:** S390X migration tests are the worst non-quarantined flakes by success rate. The eviction test at 37.5% (7d) is a strong quarantine candidate. These are S390X-specific and don't appear in other lanes.
+
+### [pull-kubevirt-e2e-kind-1.35-sig-compute-arm64](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.35-sig-compute-arm64)
+
+| Failures (28d) | Share | Builds | 7d Failures | 7d Share | Trend |
+|-----------------|-------|--------|-------------|----------|-------|
+| 40 | 2.10% | 540 | 18 | 3.01% | Worsening |
+
+Pod-level failures only (71.6% → 85.0%, improving in 7d).
+
+### [periodic-kubevirt-e2e-kind-1.34-sev](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-kind-1.34-sev)
+
+| Failures (28d) | Share | Builds |
+|-----------------|-------|--------|
+| 4 | 0.21% | 75 |
+
+| Test | Success Rate (28d) | Success Rate (7d) | Pattern |
+|------|--------------------|--------------------|---------|
+| [[QUARANTINE] SEV guest attestation](https://github.com/kubevirt/kubevirt/blob/main/tests/launchsecurity/sev.go#L349) `[QUARANTINE]` | 94.6% | 91.7% | Flaky |
+
+### [pull-kubevirt-e2e-kind-1.35-vgpu](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.35-vgpu)
+
+| Failures (28d) | Share | Builds |
+|-----------------|-------|--------|
+| 2 | 0.11% | 191 |
+
+| Test | Success Rate (7d) | Pattern |
+|------|-------------------|---------|
+| [Passthrough mediated device](https://github.com/kubevirt/kubevirt/blob/main/tests/mdev_configuration_allocation_test.go#L269) | 94.0% | Flaky |
+
+### [pull-kubevirt-e2e-kind-sriov](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-sriov)
+
+| Failures (28d) | Share | Builds |
+|-----------------|-------|--------|
+| 9 | 0.47% | 185 |
+
+Pod-level failures only (74.5% success rate).
+
+---
+
+## Quarantine Candidate Summary
+
+### Non-quarantined tests that should be quarantined
+
+| Test | SIG | Lanes | Worst Rate (28d) | 7d Trend | Pattern | Dispersion | Priority |
+|------|-----|-------|-------------------|----------|---------|------------|----------|
+| [Should successfully passthrough 2 emulated PCI devices](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L112) | compute | 1 periodic | 0% | Stable (0%) | Consecutive | Concentrated | **High** |
+| [Should successfully passthrough an emulated PCI device](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L111) | compute | 1 periodic + serial | 0% | Stable (0%) | Consecutive | Concentrated | **High** |
+| [Should block eviction api and migrate (S390X)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/eviction_strategy.go#L520) | compute | 1 (S390X) | 45.9% | Worsening (37.5%) | Flaky | Concentrated | **High** |
+| [Should contain virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | monitoring | 1 periodic + 1 presubmit | 30.8% (presubmit) | Worsening (0% periodic 7d) | Regression | Concentrated | **Medium** |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) | monitoring | 1 periodic + 1 presubmit | 28.1% (presubmit) | Worsening (28.6% periodic 7d) | Regression | Concentrated | **Medium** |
+| [Passt migration connectivity ipv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) | network | 3+ lanes | 82.4% | Stable | Flaky | Dispersed | **Medium** |
+| [Migrate multiple times cloud-init (S390X)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L551) | compute | 1 (S390X) | 80.6% | Worsening (75.0%) | Flaky | Concentrated | **Low** |
+
+### Quarantine debt — already quarantined but still severely broken
+
+These tests are quarantined but remain unfixed with very low success rates:
+
+| Test | SIG | Worst Rate (28d) | 7d Trend | Lanes |
+|------|-----|-------------------|----------|-------|
+| [[QUARANTINE] USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) | compute | 0% (k8s-1.34), 52.8% (k8s-1.35) | Worsening (15.4% 7d on 1.35) | 3 periodic |
+| [[QUARANTINE] USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) | compute | 0% (k8s-1.34), 52.8% (k8s-1.35) | Worsening (15.4% 7d on 1.35) | 3 periodic |
+| [[QUARANTINE] Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L650) | compute/storage | 70.0% (migrations) | Worsening (25–31% 7d) | 4+ lanes |
+| [[QUARANTINE] Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L651) | compute/storage | 70.0% (migrations) | Worsening (25–31% 7d) | 4+ lanes |
+| [[QUARANTINE] Should pause VMI on IO error](https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L167) | storage | 48.9% (k8s-1.34) | Improving (87.5–93.8% 7d) | 3 periodic |
+| [[QUARANTINE] Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) | compute | 85.3% | Improving (81–93% 7d) | 3 periodic |
+
+### Key findings
+
+1. **Cancel migration tests are regressing rapidly.** The `delete source/target migration` quarantined tests dropped from ~70–89% (28d) to 25–31% (7d) across 4+ lanes. This is the most urgent issue — something changed recently to make these much worse.
+
+2. **Monitoring tests may have a recent regression.** "Virt components metrics" and "VirtOperatorRESTErrorsBurst" are at 0–28% success in the 7d window for periodics. Investigate recent changes to monitoring infrastructure.
+
+3. **PCI device passthrough is deterministically broken on k8s-1.34.** The two emulated PCI device tests have 0% success across all 28 days on the 1.34 lane only. This is not a flake — it's a broken test/environment combination that should be quarantined or the lane configuration fixed.
+
+4. **USB passthrough flakiness is worsening.** Already quarantined but dropping from ~53% to ~15% on k8s-1.35 in the last 7 days.
+
+5. **S390X migration tests are platform-specific flakes.** The eviction test at 37.5% (7d) is the worst non-quarantined flake by rate and should be quarantined.
+
+6. **Infra stability is improving.** Pod failure rates across presubmit lanes are generally better in the 7d window, especially for k8s-1.36 lanes. The k8s-1.36 compute-migrations lane improved dramatically (52.6% → 76.0%).
+
+7. **IO error test is recovering.** The quarantined "should pause VMI on IO error" test improved from ~49–55% (28d) to 87.5–93.8% (7d) — a potential fix may have landed.

--- a/output/kubevirt/kubevirt/flake-overview/flake-overview-2026-06-24.md
+++ b/output/kubevirt/kubevirt/flake-overview/flake-overview-2026-06-24.md
@@ -1,0 +1,387 @@
+# KubeVirt Flake Overview - 2026-06-24
+
+## Summary
+
+| Metric | 28-day | 7-day | Trend |
+|--------|--------|-------|-------|
+| Analysis window | May 27 - Jun 24 | Jun 17 - Jun 24 | |
+| Total failures | 1,895 | 561 | |
+| Lanes with failures | 47 | 34 | |
+| Daily failure rate | ~67.7/day | ~80.1/day | **Worsening (+18%)** |
+
+The daily failure rate has increased 18% in the most recent 7-day window compared to the 28-day baseline. The primary drivers are:
+
+- **Cancel migration tests** (quarantined) have regressed from ~72% success to **0%** across all storage and compute-migrations lanes — this is a complete breakage, not flakiness
+- **sig-monitoring metrics tests** (NOT quarantined) have worsened from ~59% to **0%** in the periodic lane — highest-priority quarantine candidate
+- **USB passthrough** and **HostDevices PCI** (sig-compute) remain consistently broken on k8s-1.34, though PCI devices are improving significantly (17% -> 72%)
+
+**Top 3 worst SIGs by total failure count (28d):**
+1. **sig-compute**: 1,128 failures (59.5%) — dominated by USB/PCI passthrough + migrations
+2. **sig-storage**: 318 failures (16.8%) — driven by cancel migration + error disk
+3. **Platform-specific (S390X)**: 174 failures (9.2%) — eviction migration flake
+
+**Quarantine candidates:** 2 high priority, 1 medium priority
+**Quarantine debt (broken despite quarantine):** 4 tests at 0% or near-0% success
+**Infra-unstable lanes:** Pod-level failure rates range 60-82%; k8s-1.36 presubmit lanes are the worst
+
+## Navigation
+
+- [Infrastructure](#infrastructure)
+- [sig-compute](#sig-compute)
+- [sig-storage](#sig-storage)
+- [sig-network](#sig-network)
+- [sig-operator](#sig-operator)
+- [sig-monitoring](#sig-monitoring)
+- [sig-performance](#sig-performance)
+- [Platform-specific](#platform-specific)
+- [Quarantine Candidate Summary](#quarantine-candidate-summary)
+
+---
+
+## Infrastructure
+
+### Presubmit Pod-Level Failure Rates
+
+Pod-level failures represent infrastructure instability — test environment setup failures, cluster provisioning issues, or resource exhaustion. These are not test-level problems and should not be addressed by quarantining individual tests.
+
+| Lane | 28d Success Rate | 7d Success Rate | Trend |
+|------|------------------|-----------------|-------|
+| pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations | 60.1% | 79.4% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-network | 64.5% | 76.7% | Improving |
+| pull-kubevirt-e2e-k8s-1.34-sig-monitoring | 65.4% | 82.1% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute-serial | 65.7% | 77.0% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-operator | 66.1% | 78.7% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-storage | 66.3% | 80.1% | Improving |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute | 67.5% | 78.9% | Improving |
+| pull-kubevirt-e2e-kind-1.35-sig-compute-arm64 | 73.3% | 84.4% | Improving |
+| pull-kubevirt-e2e-k8s-1.35-sig-storage | 73.9% | — | — |
+| pull-kubevirt-e2e-k8s-1.34-sig-compute | 74.5% | — | — |
+| pull-kubevirt-e2e-k8s-1.35-sig-operator | 74.4% | 94.7% | Improving |
+| pull-kubevirt-e2e-k8s-1.34-sig-network | 74.6% | — | — |
+| pull-kubevirt-e2e-k8s-1.35-sig-network | 75.5% | — | — |
+| pull-kubevirt-e2e-k8s-1.34-sig-operator | 76.6% | — | — |
+| pull-kubevirt-e2e-k8s-1.35-sig-compute | 76.5% | — | — |
+| pull-kubevirt-e2e-kind-sriov | 77.1% | — | — |
+| pull-kubevirt-e2e-k8s-1.34-sig-storage | 77.4% | — | — |
+| pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network | 77.7% | — | — |
+| pull-kubevirt-check-tests-for-flakes | 78.3% | 85.7% | Improving |
+| pull-kubevirt-e2e-k8s-1.34-windows2016 | 80.3% | — | — |
+| pull-kubevirt-e2e-kind-1.35-vgpu | 81.7% | — | — |
+
+**Observation:** k8s-1.36 presubmit lanes have the worst Pod-level success rates over 28 days but show a strong improving trend in the 7d window. Infrastructure stability appears to be recovering. The k8s-1.36 lanes still have the lowest absolute rates even in 7d.
+
+### Periodic Pod-Level Failure Rates
+
+| Lane | 28d Success Rate | 7d Note |
+|------|------------------|---------|
+| periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations | 77.8% | Not in 7d top |
+| periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network | 85.1% | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc | 85.7% | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-storage | 86.4% | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-compute | 88.0% | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-storage | 88.0% | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-network | 88.1% | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-compute | 88.8% | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-compute | 88.8% | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-storage | 88.9% | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-network | 89.0% | — |
+| periodic-kubevirt-e2e-k8s-1.35-sig-operator | 88.8% | — |
+| periodic-kubevirt-e2e-k8s-1.36-sig-operator | 88.9% | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-monitoring | 89.3% | — |
+| periodic-kubevirt-e2e-test-S390X | 89.3% | — |
+| periodic-kubevirt-e2e-k8s-1.34-sig-operator | 89.9% | — |
+
+### BeforeSuite / Complete Setup Failures
+
+No lanes show complete BeforeSuite/AfterSuite failures at 0% success rate. All setup failures are captured within the Pod-level metrics above.
+
+---
+
+## sig-compute
+
+**Total 28d failures:** 1,128 (59.5% of all failures)
+**Lanes:** 15 (periodic + presubmit across k8s-1.34/1.35/1.36 + arm64 + S390X)
+
+### Periodic Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [periodic-k8s-1.34-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-compute) | 401 | 21.2% | 108 | 57 | Stable |
+| [periodic-k8s-1.36-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute) | 155 | 8.2% | 108 | 35 | Stable |
+| [periodic-k8s-1.35-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-compute) | 119 | 6.3% | 108 | 41 | Stable |
+| [periodic-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations) | 70 | 3.7% | 55 | 58 | **Worsening** |
+
+### Presubmit Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [pull-k8s-1.36-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute) | 81 | 4.3% | 519 | 10 | Improving |
+| [pull-kind-1.35-sig-compute-arm64](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.35-sig-compute-arm64) | 45 | 2.4% | 598 | 15 | Stable |
+| [pull-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations) | 33 | 1.7% | 636 | 19 | Worsening |
+| [pull-k8s-1.35-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-compute) | 14 | 0.7% | 206 | 1 | Improving |
+| [pull-k8s-1.34-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-compute) | 9 | 0.5% | 198 | 1 | Improving |
+| [pull-k8s-1.36-sig-compute-serial](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute-serial) | 7 | 0.4% | 491 | 2 | Stable |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.34-sig-compute
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) `[QUARANTINE]` | 9.5% | 40% | Improving | 3 lanes (1.34/1.35/1.36) | Flaky |
+| [USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) `[QUARANTINE]` | 9.5% | 40% | Improving | 3 lanes (1.34/1.35/1.36) | Flaky |
+| [PCI passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L112) | 17.1% | 72% | **Improving** | 1 lane (1.34 only) | Burst → recovering |
+| [PCI passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L111) | 17.1% | 72% | **Improving** | 1 lane (1.34 only) | Burst → recovering |
+| [Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) `[QUARANTINE]` | 83.8% | 84% | Stable | 3 lanes (1.34/1.35/1.36) | Flaky |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.36-sig-compute
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) `[QUARANTINE]` | 51% | 41.7% | Worsening | 3 lanes | Flaky |
+| [USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) `[QUARANTINE]` | 51% | 41.7% | Worsening | 3 lanes | Flaky |
+| [Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) `[QUARANTINE]` | 87.5% | 87.5% | Stable | 3 lanes | Flaky |
+| [ClusterProfiler subresource access](https://github.com/kubevirt/kubevirt/blob/main/tests/infrastructure/cluster-profiler.go#L62) `[QUARANTINE]` | 93.3% | — | Not in 7d | 1 lane | Flaky |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.35-sig-compute
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) `[QUARANTINE]` | 51% | 37.5% | Worsening | 3 lanes | Flaky |
+| [USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) `[QUARANTINE]` | 51% | 37.5% | Worsening | 3 lanes | Flaky |
+| [Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) `[QUARANTINE]` | 89% | — | Not in 7d | 3 lanes | Flaky |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) `[QUARANTINE]` | 42% | **0%** | **Severely worsening** | 4+ lanes | Consecutive |
+| [Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) `[QUARANTINE]` | 42% | **0%** | **Severely worsening** | 4+ lanes | Consecutive |
+| [Post-copy migration liveness probe](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/postcopy.go#L176) `[QUARANTINE]` | 87.5% | 87.5% | Stable | 1 lane | Flaky |
+| [Abort VMI migration](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L1499) | — | 92.3% | — | 1 lane | Flaky |
+
+### Failing Tests — pull-kubevirt-e2e-k8s-1.36-sig-compute-serial (DRA tests)
+
+All DRA tests fail at 0% success rate with 1-2 total runs each. These are **infra-correlated** — they share the same build IDs and all require vfio-gpu hardware that appears unavailable in the test environment. Not quarantine candidates; the test infrastructure needs DRA/vfio-gpu support.
+
+| Test | 28d Rate | 7d Rate | Pattern |
+|------|----------|---------|---------|
+| [DRA — allocate vfio-gpu by pciBusId](https://github.com/kubevirt/kubevirt/blob/main/tests/) | 0% (1 run) | 0% (1 run) | Infra-correlated |
+| DRA — allocate vfio-gpu by vendorID | 0% (1 run) | 0% (1 run) | Infra-correlated |
+| DRA — allocate three vfio-gpu devices | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — matchAttribute vendorID | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — pre-created ResourceClaim | 0% (1 run) | 0% (1 run) | Infra-correlated |
+| DRA — four VMIs individual claims | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — four VMIs ResourceClaimTemplate | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — more than one device per request | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — matchattribute different values | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — unknown resourceClaim | 0% (1 run) | 0% (1 run) | Infra-correlated |
+| DRA — CEL selector no device | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+| DRA — CEL invalid attribute access | 0% (2 runs) | 0% (2 runs) | Infra-correlated |
+
+### Failing Tests — pull-kubevirt-e2e-kind-1.35-sig-compute-arm64
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [libvirtd logs](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_lifecycle_test.go#L178) | — | 94.8% | — | 2 lanes (arm64 + 1.36 periodic) | Flaky |
+
+---
+
+## sig-storage
+
+**Total 28d failures:** 318 (16.8% of all failures)
+**Lanes:** 6 (periodic + presubmit across k8s-1.34/1.35/1.36)
+
+### Periodic Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [periodic-k8s-1.34-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-storage) | 103 | 5.4% | 108 | 50 | Worsening |
+| [periodic-k8s-1.36-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage) | 97 | 5.1% | 110 | 53 | Worsening |
+| [periodic-k8s-1.35-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-storage) | 95 | 5.0% | 109 | 52 | Worsening |
+
+### Presubmit Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [pull-k8s-1.36-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-storage) | 18 | 0.9% | 510 | 4 | Improving |
+| [pull-k8s-1.34-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-storage) | 8 | 0.4% | 213 | 2 | Stable |
+| [pull-k8s-1.35-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-storage) | 6 | 0.3% | 215 | 2 | Stable |
+
+### Failing Tests — periodic sig-storage (all k8s versions)
+
+The cancel migration tests dominate storage lane failures. The error disk test has improved.
+
+| Test | 28d Rate (1.34) | 28d Rate (1.35) | 28d Rate (1.36) | 7d Rate | Trend | Dispersion | Pattern |
+|------|-----------------|-----------------|-----------------|---------|-------|------------|---------|
+| [Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) `[QUARANTINE]` | 71.8% | 72.1% | 72.1% | **0%** (all) | **Severely worsening** | 6+ lanes | Consecutive |
+| [Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) `[QUARANTINE]` | 71.8% | 73.1% | 72.1% | **0%** (all) | **Severely worsening** | 6+ lanes | Consecutive |
+| [Error disk IO pause](https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L167) `[QUARANTINE]` | 54.1% | 62.6% | 62.2% | — | **Not in 7d** | 3 lanes (1.34/1.35/1.36) | Improving |
+
+---
+
+## sig-network
+
+**Total 28d failures:** 162 (8.6% of all failures)
+**Lanes:** 10 (periodic + presubmit across k8s versions + IPv6 + DNC)
+
+### Periodic Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [periodic-k8s-1.35-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-network) | 23 | 1.2% | 110 | 3 | Stable |
+| [periodic-k8s-1.36-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-network) | 21 | 1.1% | 109 | 9 | Worsening |
+| [periodic-k8s-1.34-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-network) | 9 | 0.5% | 108 | 2 | Stable |
+| [periodic-k8s-1.36-sig-network-with-dnc](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc) | 4 | 0.2% | 21 | 1 | Stable |
+| [periodic-k8s-1.36-ipv6-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network) | 1 | 0.1% | 87 | — | Stable |
+
+### Presubmit Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [pull-k8s-1.35-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-network) | 30 | 1.6% | 211 | 4 | Improving |
+| [pull-k8s-1.34-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-network) | 27 | 1.4% | 216 | 8 | Stable |
+| [pull-k8s-1.36-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-network) | 24 | 1.3% | 526 | 3 | Improving |
+| [pull-k8s-1.36-ipv6-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network) | 10 | 0.5% | 222 | 8 | Worsening |
+
+### Failing Tests
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [Passt migration connectivity IPv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) `[QUARANTINE]` | 79-91% | 79-91% | Stable | 2 lanes (1.34/1.36 periodic) | Flaky |
+| [Bridge nic-hotplug multiple interfaces](https://github.com/kubevirt/kubevirt/blob/main/tests/network/hotplug_bridge.go#L275) | 85.7% | 85.7% | Stable | 1 lane (DNC only) | Flaky |
+| Passt TCP connectivity IPv4 | — | 92.3% | — | 1 lane (1.36 periodic) | Flaky |
+
+---
+
+## sig-operator
+
+**Total 28d failures:** 162 (8.6% of all failures)
+**Lanes:** 6 (periodic + presubmit across k8s-1.34/1.35/1.36)
+
+### Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [pull-k8s-1.35-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-operator) | 59 | 3.1% | 198 | 1 | **Improving** |
+| [pull-k8s-1.36-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-operator) | 49 | 2.6% | 491 | 1 | **Improving** |
+| [periodic-k8s-1.34-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-operator) | 45 | 2.4% | 109 | 44 | **Worsening** |
+| [periodic-k8s-1.35-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-operator) | 3 | 0.2% | 108 | 1 | Stable |
+| [periodic-k8s-1.36-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-operator) | 2 | 0.1% | 108 | — | Stable |
+| [pull-k8s-1.34-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-operator) | 1 | 0.1% | 191 | — | Stable |
+
+No test-level failures identified in sig-operator lanes — all failures are Pod-level infrastructure issues. The periodic-k8s-1.34-sig-operator lane shows anomalous 7d failure count (44 of 45 total 28d failures occurred in the last 7 days), suggesting a recent infrastructure regression on k8s-1.34 for this lane. Presubmit lanes are improving significantly.
+
+---
+
+## sig-monitoring
+
+**Total 28d failures:** 61 (3.2% of all failures)
+**Lanes:** 2 (periodic-k8s-1.34-sig-monitoring + pull-k8s-1.34-sig-monitoring)
+
+### Lanes
+
+| Lane | 28d Failures | Share | Builds | 7d Failures | Trend |
+|------|-------------|-------|--------|-------------|-------|
+| [periodic-k8s-1.34-sig-monitoring](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-monitoring) | 57 | 3.0% | 56 | 28 | **Worsening** |
+| [pull-k8s-1.34-sig-monitoring](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-monitoring) | 4 | 0.2% | 82 | 3 | Worsening |
+
+### Failing Tests
+
+| Test | 28d Rate | 7d Rate | Trend | Dispersion | Pattern |
+|------|----------|---------|-------|------------|---------|
+| [Prometheus virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | 59.3% (periodic) / 30% (presubmit) | **0% (periodic)** / 23.3% (presubmit) | **Severely worsening** | 3 lanes (periodic + presubmit + check-for-flakes) | Consecutive |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) | 66.7% (periodic) / 32.6% (presubmit) | 30% (periodic) / 36.4% (presubmit) | Worsening | 2 lanes | Flaky |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) `[QUARANTINE]` | 33.3% (periodic) | 33.3% | Stable | 1 lane | Flaky |
+| [VM dirty rate metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/vm_monitoring.go#L334) `[QUARANTINE]` | 87% | 85.7% | Stable | 1 lane | Flaky |
+| [Alert rule annotations](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/monitoring.go#L68) | 91.8% (presubmit) | 92.9% (periodic) | Stable | 2 lanes | Flaky |
+| [VNIC metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L132) | 94.7% (presubmit) | 87.5% (presubmit) | Slightly worsening | 1 lane | Flaky |
+| VirtControllerDown bad image | 0% (1 run) | 0% (1 run) | — | 1 lane | Low sample |
+| [VirtOperatorDown](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L133) | — | 92.9% | — | 1 lane | Flaky |
+
+**Key finding:** The `should contain virt components metrics` test has deteriorated from 59% success to **0% in the periodic lane** over 7 days (14 consecutive failures). This is the highest-priority quarantine candidate in the project. The `VirtOperatorRESTErrorsBurst` test exists in both quarantined and non-quarantined forms — the non-quarantined version should also be quarantined.
+
+---
+
+## sig-performance
+
+**Total 28d failures:** 12 (0.6% of all failures)
+**Lanes:** 3 (periodic-k8s-1.34-sig-performance, periodic-k8s-1.34-sig-performance-kwok, periodic-kind-1.34-sev)
+
+All failures are Pod-level infrastructure issues only. No test-level failures detected. This SIG has the lowest failure rate across the project.
+
+| Lane | 28d Failures | Pod Success Rate |
+|------|-------------|-----------------|
+| [periodic-k8s-1.34-sig-performance-kwok](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok) | 5 | 88.5% |
+| [periodic-kind-1.34-sev](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-kind-1.34-sev) | 4 | 89.2% |
+| [periodic-k8s-1.34-sig-performance](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance) | 3 | 88.0% |
+
+---
+
+## Platform-specific
+
+### S390X — periodic-kubevirt-e2e-test-S390X
+
+**28d failures:** 174 (9.2%) | **7d failures:** 39 (7.0%) | **Builds:** 112 (28d), 28 (7d)
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern |
+|------|----------|---------|-------|---------|
+| [Eviction strategy — block eviction and migrate](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/eviction_strategy.go#L86) | 48.6% | 63% | Improving | Flaky |
+| [Migration multiple times cloud-init](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L551) | 81.7% | 88.9% | Improving | Flaky |
+| [Migrate after virtqemud restart](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L589) | 91.7% | 92.6% | Stable | Flaky |
+| [CfgMap/secret fs layout](https://github.com/kubevirt/kubevirt/blob/main/tests/config_test.go#L520) | 94.5% | 88.9% | Slightly worsening | Flaky |
+| [CPU hotplug vCPUs](https://github.com/kubevirt/kubevirt/blob/main/tests/hotplug/cpu.go#L106) | — | 92.6% | — | Flaky |
+| Port-forward VMI IPv4 | — | 92.6% | — | Flaky |
+| MTU verification IPv4 | — | 92.6% | — | Flaky |
+
+The S390X eviction migration test at 48.6% (28d) is the worst non-quarantined test on this platform. It's improving (63% in 7d) but remains unreliable. It is **concentrated to S390X** — other platforms don't show this failure, making it a platform-specific issue rather than a test code problem.
+
+### ARM64 — pull-kubevirt-e2e-kind-1.35-sig-compute-arm64
+
+**28d failures:** 45 (2.4%) | **7d failures:** 15 (2.7%) | Pod-only in 28d, one test failure in 7d.
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern |
+|------|----------|---------|-------|---------|
+| [libvirtd logs](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_lifecycle_test.go#L178) | — | 94.8% | — | Flaky |
+
+### Other Presubmit Lanes
+
+| Lane | 28d Failures | Pod Success Rate | 7d |
+|------|-------------|------------------|----|
+| [pull-kind-sriov](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-sriov) | 11 | 77.1% | 2 |
+| [pull-kind-1.35-vgpu](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.35-vgpu) | 2 | 81.7% | 1 |
+| [pull-k8s-1.34-windows2016](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-windows2016) | 1 | 80.3% | — |
+
+All failures in these lanes are Pod-level infrastructure issues only.
+
+---
+
+## Quarantine Candidate Summary
+
+### New Quarantine Candidates
+
+| Test | SIG | Lanes | Worst Rate (28d) | 7d Trend | Pattern | Dispersion | Priority |
+|------|-----|-------|-------------------|----------|---------|------------|----------|
+| [Prometheus virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | sig-monitoring | 3 (periodic + presubmit + check-for-flakes) | 8.3% | Worsening (0% periodic) | Consecutive | Dispersed | **High** |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) (non-quarantined) | sig-monitoring | 2 (periodic + presubmit) | 32.6% | Worsening | Flaky | Concentrated | **High** |
+| [HostDevices PCI passthrough](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L111) (2 tests) | sig-compute | 1 (k8s-1.34 periodic) | 17.1% | Improving (72% in 7d) | Burst → recovering | Concentrated | **Medium** |
+
+### Quarantine Debt (quarantined but still severely broken)
+
+These tests were quarantined but never fixed. They continue to consume CI resources and mask real signal.
+
+| Test | SIG | Worst Rate (28d) | 7d Rate | Lanes | Status |
+|------|-----|-------------------|---------|-------|--------|
+| [Cancel migration — delete source](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) | sig-compute | 42% | **0%** | 6+ (storage + migrations, all k8s versions) | **Regression — completely broken** |
+| [Cancel migration — delete target](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) | sig-compute | 42% | **0%** | 6+ (storage + migrations, all k8s versions) | **Regression — completely broken** |
+| [USB passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) | sig-compute | 9.5% | 37.5-41.7% | 3 (1.34/1.35/1.36 periodic) | Improving on 1.34, worsening on 1.35/1.36 |
+| [USB passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) | sig-compute | 9.5% | 37.5-41.7% | 3 (1.34/1.35/1.36 periodic) | Same as above |
+| [Error disk IO pause](https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L167) | sig-storage | 54.1% | Not in 7d | 3 (all k8s versions) | May be improving |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) (quarantined variant) | sig-monitoring | 33.3% | 33.3% | 1 | Stable — not being fixed |
+
+---
+
+## Suggested Follow-Up Analysis
+
+- **lane-failure-rate** on `periodic-kubevirt-e2e-k8s-1.34-sig-operator` — the 7d failure spike (44 of 45 total 28d failures in last 7 days) suggests a recent infrastructure regression that warrants investigation
+- **lane-failure-rate** on `periodic-kubevirt-e2e-k8s-1.34-sig-monitoring` — the `virt components metrics` test going to 0% in 7d needs root cause analysis
+- **analyze-build** on recent `periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations` builds — the cancel migration tests hitting 0% success rate suggests a code regression, not flakiness
+- **lane-failure-rate** on `periodic-kubevirt-e2e-test-S390X` — the eviction migration test at ~50% needs flip-rate analysis to determine if it's a genuine flake or intermittent infra issue

--- a/output/kubevirt/kubevirt/flake-overview/flake-overview-2026-06-29.md
+++ b/output/kubevirt/kubevirt/flake-overview/flake-overview-2026-06-29.md
@@ -1,0 +1,375 @@
+# Flake Overview Report — 2026-06-29
+
+## Summary
+
+| Window | Total Failures | Lanes | Failures/Day |
+|--------|---------------|-------|--------------|
+| 28d (Jun 1–29) | 2,058 | 45 | 73.5 |
+| 7d (Jun 22–29) | 633 | 33 | 90.4 |
+
+**Overall trend: Worsening** — daily failure rate increased ~23% in the last 7 days compared to the 28-day average.
+
+**Top 3 worst SIGs by failure count (28d):**
+1. **sig-compute** — 896 failures (43.5%) across periodic + presubmit compute/migration lanes
+2. **sig-storage** — 403 failures (19.6%) — dominated by migration-cancel quarantine debt
+3. **Platform-specific (S390X/arm64)** — 244 failures (11.9%)
+
+**Quarantine candidates identified:** 2 high priority, 1 medium priority
+**Quarantine debt (broken quarantined tests):** 5 tests at 0% success in 7d
+**Infra-unstable lanes:** k8s-1.36 presubmit lanes show elevated Pod-level failure rates (73–79%)
+
+### Key changes this week
+
+- **Live Migration cancel migration tests dropped to 0% success** across all lanes in 7d — already quarantined but now a deterministic regression, not a flake
+- **KWOK density tests worsened sharply** from ~88% to ~47-57% success rate — emerging regression, not yet quarantined
+- **k8s-1.36 presubmit infrastructure instability** — Pod-level failures at 73-80% across most k8s-1.36 presubmit lanes
+
+## Navigation
+
+- [Infrastructure](#infrastructure)
+- [sig-compute](#sig-compute)
+- [sig-storage](#sig-storage)
+- [sig-network](#sig-network)
+- [sig-operator](#sig-operator)
+- [sig-monitoring](#sig-monitoring)
+- [sig-performance](#sig-performance)
+- [Platform-specific](#platform-specific)
+- [Quarantine Candidate Summary](#quarantine-candidate-summary)
+
+---
+
+## Infrastructure
+
+### Presubmit Pod-Level Failure Rates
+
+Pod-level failures represent infrastructure instability — builds that fail before any test code runs.
+
+| Lane | 28d Success | 7d Success | Trend | Builds (28d) |
+|------|------------|------------|-------|-------------|
+| pull-kubevirt-e2e-k8s-1.36-sig-storage.Pod | 72.3% | 78.6% | Improving | 511 |
+| pull-kubevirt-e2e-k8s-1.36-sig-network.Pod | 72.8% | 79.9% | Improving | 513 |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations.Pod | 73.6% | 79.6% | Improving | 569 |
+| pull-kubevirt-e2e-k8s-1.36-sig-operator.Pod | 73.6% | 79.0% | Improving | 489 |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute-serial.Pod | 74.3% | N/A | — | 484 |
+| pull-kubevirt-e2e-k8s-1.36-sig-compute.Pod | 76.3% | 82.8% | Improving | 500 |
+| pull-kubevirt-e2e-kind-1.35-sig-compute-arm64.Pod | 82.6% | 88.9% | Improving | 573 |
+| pull-kubevirt-check-tests-for-flakes.Pod | 84.9% | 93.3% | Improving | 554 |
+| pull-kubevirt-e2e-k8s-1.34-sig-monitoring.Pod | 70.3% | 81.3% | Improving | 75 |
+
+**Assessment:** The k8s-1.36 presubmit lanes have the worst infrastructure reliability at 72-80% Pod-level success. While the 7d trend shows slight improvement across the board, one in five builds still fails at the infrastructure level on k8s-1.36 presubmit lanes. This wastes significant CI capacity and creates false-negative pressure on all test results in those lanes.
+
+### Periodic Pod-Level Failure Rates
+
+| Lane | 28d Success | 7d Success | Builds (28d) |
+|------|------------|------------|-------------|
+| periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations.Pod | 82.4% | N/A | 74 |
+| periodic-kubevirt-e2e-k8s-1.36-sig-storage.Pod | 86.4% | N/A | 111 |
+| periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network.Pod | 86.8% | N/A | 107 |
+| periodic-kubevirt-e2e-k8s-1.34-sig-compute.Pod | 86.9% | N/A | 108 |
+| periodic-kubevirt-e2e-k8s-1.34-sig-network.Pod | 87.9% | N/A | 108 |
+| periodic-kubevirt-e2e-test-S390X.Pod | 88.2% | N/A | 111 |
+
+Periodic Pod-level failures are moderate (82-89% success), with k8s-1.36 sig-compute-migrations being the worst.
+
+---
+
+## sig-compute
+
+**Total 28d failures:** 896 (43.5%) | **7d failures:** 278 (43.9%) | **Trend:** Stable share
+
+### Periodic Lanes
+
+| Lane | 28d Failures | 28d Share | 7d Failures | 7d Share | Builds (28d) | Trend |
+|------|-------------|-----------|-------------|----------|-------------|-------|
+| [periodic-kubevirt-e2e-k8s-1.34-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-compute) | 344 | 16.72% | 32 | 5.06% | 108 | Improving |
+| [periodic-kubevirt-e2e-k8s-1.36-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute) | 139 | 6.75% | 33 | 5.21% | 107 | Stable |
+| [periodic-kubevirt-e2e-k8s-1.35-sig-compute](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-compute) | 131 | 6.37% | 31 | 4.90% | 108 | Stable |
+| [periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations) | 116 | 5.64% | 63 | 9.95% | 74 | **Worsening** |
+
+### Presubmit Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations) | 61 | 32 | 569 | **Worsening** |
+| [pull-kubevirt-e2e-k8s-1.36-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute) | 45 | 13 | 500 | Stable |
+| [pull-kubevirt-e2e-k8s-1.35-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-compute) | 16 | 7 | 189 | Stable |
+| [pull-kubevirt-e2e-k8s-1.34-sig-compute](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-compute) | 10 | 4 | 180 | Stable |
+| [pull-kubevirt-e2e-k8s-1.36-sig-compute-serial](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute-serial) | 6 | N/A | 484 | — |
+| [pull-kubevirt-check-tests-for-flakes](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-check-tests-for-flakes) | 6 | 4 | 554 | Stable |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.34-sig-compute
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [USB 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) [QUARANTINE] | 18.1% | 52.0% | Improving | Flaky | Dispersed (3 lanes) |
+| [USB 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) [QUARANTINE] | 18.1% | 52.0% | Improving | Flaky | Dispersed (3 lanes) |
+| [PCI passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L112) | 34.3% | N/A | Improving | Flaky | Concentrated (1 lane) |
+| [PCI passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L111) | 34.3% | N/A | Improving | Flaky | Concentrated (1 lane) |
+| [Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) [QUARANTINE] | 85.7% | 88.0% | Stable | Flaky | Dispersed (3 lanes) |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.36-sig-compute
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [USB 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) [QUARANTINE] | 48.5% | 45.8% | Stable | Flaky | Dispersed (3 lanes) |
+| [USB 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) [QUARANTINE] | 48.5% | 45.8% | Stable | Flaky | Dispersed (3 lanes) |
+| [Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) [QUARANTINE] | 87.4% | 91.7% | Stable | Flaky | Dispersed (3 lanes) |
+| [ClusterProfiler pprof](https://github.com/kubevirt/kubevirt/blob/main/tests/infrastructure/cluster-profiler.go#L62) [QUARANTINE] | 93.2% | 91.7% | Stable | Flaky | Concentrated (1 lane) |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.35-sig-compute
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [USB 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) [QUARANTINE] | 45.2% | 46.2% | Stable | Flaky | Dispersed (3 lanes) |
+| [USB 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) [QUARANTINE] | 45.2% | 46.2% | Stable | Flaky | Dispersed (3 lanes) |
+| [Guest console log flood](https://github.com/kubevirt/kubevirt/blob/main/tests/guestlog/guestlog.go#L159) [QUARANTINE] | 89.4% | 92.3% | Stable | Flaky | Dispersed (3 lanes) |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [Cancel migration (delete source)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) [QUARANTINE] | 30.0% | **0.0%** | **Worsening** | Consecutive | Dispersed (4+ lanes) |
+| [Cancel migration (delete target)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) [QUARANTINE] | 30.0% | **0.0%** | **Worsening** | Consecutive | Dispersed (4+ lanes) |
+| [Post-copy migration liveness probe](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/postcopy.go#L176) [QUARANTINE] | 86.4% | 85.2% | Stable | Flaky | Concentrated (1 lane) |
+| [Abort a vmi migration](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L1499) | 94.3% | 92.6% | Stable | Flaky | Dispersed (2 lanes) |
+
+### Failing Tests — pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [Abort a vmi migration](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L1499) | 93.3% | 88.6% | **Worsening** | Flaky | Dispersed (2 lanes) |
+| [Live Migrations with priority](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/priority.go#L76) | N/A | 94.0% | New | Flaky | Concentrated (1 lane) |
+
+### Failing Tests — pull-kubevirt-check-tests-for-flakes
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [PCI Port Allocation (1Gi, 0 devs)](https://github.com/kubevirt/kubevirt/blob/main/tests/hotplug/pci-ports.go#L46) | 75.0% | N/A | — | Flaky | Concentrated (1 lane) |
+| [PCI Port Allocation (2.1Gi, 6 devs)](https://github.com/kubevirt/kubevirt/blob/main/tests/hotplug/pci-ports.go#L46) | 75.0% | N/A | — | Flaky | Concentrated (1 lane) |
+
+---
+
+## sig-storage
+
+**Total 28d failures:** 403 (19.6%) | **7d failures:** 166 (26.2%) | **Trend:** Worsening share
+
+### Periodic Lanes
+
+| Lane | 28d Failures | 28d Share | 7d Failures | 7d Share | Builds (28d) | Trend |
+|------|-------------|-----------|-------------|----------|-------------|-------|
+| [periodic-kubevirt-e2e-k8s-1.36-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-storage) | 130 | 6.32% | 57 | 9.00% | 111 | **Worsening** |
+| [periodic-kubevirt-e2e-k8s-1.34-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-storage) | 129 | 6.27% | 50 | 7.90% | 109 | **Worsening** |
+| [periodic-kubevirt-e2e-k8s-1.35-sig-storage](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-storage) | 120 | 5.83% | 50 | 7.90% | 108 | **Worsening** |
+
+### Presubmit Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [pull-kubevirt-e2e-k8s-1.36-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-storage) | 10 | 4 | 511 | Stable |
+| [pull-kubevirt-e2e-k8s-1.34-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-storage) | 8 | 3 | 195 | Stable |
+| [pull-kubevirt-e2e-k8s-1.35-sig-storage](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-storage) | 6 | 2 | 190 | Stable |
+
+### Failing Tests — All sig-storage periodic lanes (identical pattern)
+
+The sig-storage lanes run the migration cancel tests and these dominate all failures.
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [Cancel migration (delete source)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) [QUARANTINE] | 53.8% | **0.0%** | **Worsening** | Consecutive | Dispersed (4+ lanes) |
+| [Cancel migration (delete target)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) [QUARANTINE] | 53.8–54.8% | **0.0%** | **Worsening** | Consecutive | Dispersed (4+ lanes) |
+
+---
+
+## sig-network
+
+**Total 28d failures:** 133 (6.5%) | **7d failures:** 15 (2.4%) | **Trend:** Improving
+
+### Periodic Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [periodic-kubevirt-e2e-k8s-1.35-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-network) | 21 | 3 | 109 | Stable |
+| [periodic-kubevirt-e2e-k8s-1.36-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-network) | 20 | 1 | 111 | Improving |
+| [periodic-kubevirt-e2e-k8s-1.34-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-network) | 10 | 2 | 108 | Stable |
+| [periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc) | 5 | 2 | 26 | Stable |
+| [periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network) | 2 | 1 | 107 | Stable |
+
+### Presubmit Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [pull-kubevirt-e2e-k8s-1.35-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-network) | 31 | 3 | 186 | Stable |
+| [pull-kubevirt-e2e-k8s-1.36-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-network) | 26 | 3 | 513 | Stable |
+| [pull-kubevirt-e2e-k8s-1.34-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-network) | 25 | N/A | 194 | — |
+| [pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network) | 10 | N/A | 204 | — |
+
+### Failing Tests
+
+| Test | Lane(s) | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|---------|----------|---------|-------|---------|------------|
+| [Passt binding migration connectivity IPv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/passt.go#L280) [QUARANTINE] | periodic 1.34/1.35/1.36 | 88.6–92.9% | 91.7–92.3% | Stable | Flaky | Dispersed (3 lanes) |
+| [Bridge nic-hotplug multiple interfaces In place](https://github.com/kubevirt/kubevirt/blob/main/tests/network/hotplug_bridge.go#L215) | periodic 1.36-with-dnc | 84.6% | 71.4% | **Worsening** | Flaky | Concentrated (1 lane) |
+
+---
+
+## sig-operator
+
+**Total 28d failures:** 239 (11.6%) | **7d failures:** 95 (15.0%) | **Trend:** Worsening share
+
+### Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [pull-kubevirt-e2e-k8s-1.36-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-operator) | 100 | 51 | 489 | **Worsening** |
+| [pull-kubevirt-e2e-k8s-1.35-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.35-sig-operator) | 47 | N/A | 180 | — |
+| [periodic-kubevirt-e2e-k8s-1.34-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-operator) | 45 | N/A | 109 | — |
+| [pull-kubevirt-e2e-k8s-1.34-sig-operator](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-operator) | 44 | 44 | 178 | Stable |
+| [periodic-kubevirt-e2e-k8s-1.35-sig-operator](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-operator) | 3 | N/A | 108 | — |
+
+**Assessment:** sig-operator failures are exclusively Pod-level (infrastructure) — no individual test failures were reported. The pull-kubevirt-e2e-k8s-1.36-sig-operator lane has the worst Pod-level success rate (73.6% 28d / 79.0% 7d), accounting for half of all sig-operator failures.
+
+---
+
+## sig-monitoring
+
+**Total 28d failures:** 78 (3.8%) | **7d failures:** 37 (5.8%) | **Trend:** Worsening share
+
+### Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [periodic-kubevirt-e2e-k8s-1.34-sig-monitoring](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-monitoring) | 61 | 20 | 56 | Stable |
+| [pull-kubevirt-e2e-k8s-1.34-sig-monitoring](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-sig-monitoring) | 17 | 17 | 75 | Stable |
+
+### Failing Tests — periodic-kubevirt-e2e-k8s-1.34-sig-monitoring
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) [QUARANTINE] | 30.0% | 30.0% | Stable | Flaky | Concentrated (1 lane) |
+| [Virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | 60.7% | 71.4% | Improving | Flaky | Dispersed (2 lanes) |
+| [VM dirty rate metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/vm_monitoring.go#L334) [QUARANTINE] | 92.9% | 92.9% | Stable | Flaky | Concentrated (1 lane) |
+| [LowReadyVirtHandlerCount](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L272) | N/A | 91.7% | New in 7d | Flaky | Concentrated (1 lane) |
+| [VirtAPIDown](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L171) | N/A | 92.3% | New in 7d | Flaky | Concentrated (1 lane) |
+| [VirtControllerDown](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L149) | N/A | 92.9% | New in 7d | Flaky | Concentrated (1 lane) |
+| [VM count metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/vm_monitoring.go#L393) | N/A | 92.9% | New in 7d | Flaky | Concentrated (1 lane) |
+| [Orphaned VMIs alert](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/vm_monitoring.go#L510) | N/A | 92.9% | New in 7d | Flaky | Concentrated (1 lane) |
+
+### Failing Tests — pull-kubevirt-e2e-k8s-1.34-sig-monitoring
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|----------|---------|-------|---------|------------|
+| [Virt components metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L119) | 29.1% | 54.2% | Improving | Flaky | Dispersed (2 lanes) |
+| [VNIC metrics](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/metrics.go#L132) | 94.1% | 92.9% | Stable | Flaky | Concentrated (1 lane) |
+
+**Note:** The "virt components metrics" test has been quarantined in code ([QUARANTINE] tag added) but may appear without the tag in older flakefinder data. Its success rate is improving from 29-61% to 54-71%.
+
+---
+
+## sig-performance
+
+**Total 28d failures:** 36 (1.7%) | **7d failures:** 32 (5.1%) | **Trend:** Worsening
+
+### Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok) | 20 | 16 | 78 | **Worsening** |
+| [periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok-100](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok-100) | 16 | 16 | 84 | **Worsening** |
+
+### Failing Tests
+
+| Test | Lane | 28d Rate | 7d Rate | Trend | Pattern | Dispersion |
+|------|------|----------|---------|-------|---------|------------|
+| [KWOK fake VMIs](https://github.com/kubevirt/kubevirt/blob/main/tests/performance/density-kwok.go#L89) | kwok | 87.8% | **47.1%** | **Worsening** | Burst/regression | Dispersed (2 lanes) |
+| [KWOK fake VMs](https://github.com/kubevirt/kubevirt/blob/main/tests/performance/density-kwok.go#L105) | kwok | 87.8% | **47.1%** | **Worsening** | Burst/regression | Dispersed (2 lanes) |
+| [KWOK fake VMIs](https://github.com/kubevirt/kubevirt/blob/main/tests/performance/density-kwok.go#L89) | kwok-100 | 89.2% | **57.1%** | **Worsening** | Burst/regression | Dispersed (2 lanes) |
+| [KWOK fake VMs](https://github.com/kubevirt/kubevirt/blob/main/tests/performance/density-kwok.go#L105) | kwok-100 | 89.2% | **57.1%** | **Worsening** | Burst/regression | Dispersed (2 lanes) |
+
+**Assessment:** The KWOK density tests have degraded sharply this week — dropping from ~88-89% to 47-57% success rate. Both the VMI and VM variants fail together, and both kwok and kwok-100 lanes are affected, suggesting a regression in the KWOK density test infrastructure or the control plane performance that these tests measure. These tests are **not quarantined** and should be investigated for a recent regression. 9 out of 17-21 runs are failing in the 7d window.
+
+---
+
+## Platform-specific
+
+### S390X
+
+**28d failures:** 166 (8.07%) | **7d failures:** 37 (5.85%) | **Trend:** Improving
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [periodic-kubevirt-e2e-test-S390X](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-test-S390X) | 166 | 37 | 111 | Improving |
+
+#### Failing Tests
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern |
+|------|----------|---------|-------|---------|
+| [Eviction strategy block and migrate](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/eviction_strategy.go#L520) | 56.1% | N/A | Improving | Burst |
+| [Virt-handler crash recovery](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_lifecycle_test.go#L492) | N/A | 84.6% | New in 7d | Flaky |
+| [VMPool scale-in offline](https://github.com/kubevirt/kubevirt/blob/main/tests/pool_test.go#L881) | N/A | 84.6% | New in 7d | Flaky |
+| [Multi-migration cloud-init](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L551) | 84.1% | 88.5% | Stable | Flaky |
+| [Virtqemud restart migration](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L589) | 91.6% | N/A | Improving | Flaky |
+| [CfgMap/Secret fs layout](https://github.com/kubevirt/kubevirt/blob/main/tests/config_test.go#L520) | 94.4% | N/A | Improving | Flaky |
+| [ReplicaSet server-side printing](https://github.com/kubevirt/kubevirt/blob/main/tests/replicaset_test.go#L236) | N/A | 92.3% | New in 7d | Flaky |
+| [Masquerade MTU IPv4](https://github.com/kubevirt/kubevirt/blob/main/tests/network/vmi_networking.go#L720) | N/A | 92.3% | New in 7d | Flaky |
+
+**Assessment:** S390X is improving overall. The worst 28d test (eviction strategy at 56%) did not appear in 7d top failures, suggesting a fix or transient burst. Several new low-severity flakes appeared in 7d (84-92% range) — worth monitoring but not quarantine-worthy yet since they're all concentrated in the S390X lane (platform-specific).
+
+### ARM64
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [pull-kubevirt-e2e-kind-1.35-sig-compute-arm64](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.35-sig-compute-arm64) | 65 | 25 | 573 | Improving |
+
+ARM64 failures are exclusively Pod-level (82.6% 28d → 88.9% 7d, improving).
+
+### SEV
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) | Trend |
+|------|-------------|-------------|-------------|-------|
+| [periodic-kubevirt-e2e-kind-1.34-sev](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-kind-1.34-sev) | 5 | 3 | 83 | Stable |
+
+| Test | 28d Rate | 7d Rate | Trend | Pattern |
+|------|----------|---------|-------|---------|
+| [SEV guest attestation](https://github.com/kubevirt/kubevirt/blob/main/tests/launchsecurity/sev.go#L349) [QUARANTINE] | 93.9% | 85.0% | **Worsening** | Flaky |
+
+### Other Platform Lanes
+
+| Lane | 28d Failures | 7d Failures | Builds (28d) |
+|------|-------------|-------------|-------------|
+| [pull-kubevirt-e2e-kind-sriov](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-sriov) | 7 | 3 | 198 |
+| [pull-kubevirt-e2e-kind-1.35-vgpu](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.35-vgpu) | 1 | N/A | 219 |
+| [pull-kubevirt-e2e-k8s-1.34-windows2016](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.34-windows2016) | 1 | N/A | 221 |
+
+---
+
+## Quarantine Candidate Summary
+
+### New quarantine candidates (not yet quarantined)
+
+| Test | SIG | Lanes | Worst Rate (28d) | 7d Trend | Pattern | Dispersion | Priority |
+|------|-----|-------|-------------------|----------|---------|------------|----------|
+| [KWOK fake VMIs](https://github.com/kubevirt/kubevirt/blob/main/tests/performance/density-kwok.go#L89) | sig-performance | kwok, kwok-100 | 87.8% | **Worsening to 47%** | Burst/regression | Dispersed (2) | **High** |
+| [KWOK fake VMs](https://github.com/kubevirt/kubevirt/blob/main/tests/performance/density-kwok.go#L105) | sig-performance | kwok, kwok-100 | 87.8% | **Worsening to 47%** | Burst/regression | Dispersed (2) | **High** |
+| [PCI passthrough 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L112) | sig-compute | periodic 1.34 | 34.3% | Improving (absent in 7d) | Flaky | Concentrated (1) | Medium |
+| [PCI passthrough 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_hostdev_test.go#L111) | sig-compute | periodic 1.34 | 34.3% | Improving (absent in 7d) | Flaky | Concentrated (1) | Medium |
+| [Abort a vmi migration](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/migration.go#L1499) | sig-compute | periodic + presubmit migrations | 93.3% | **Worsening to 88.6%** | Flaky | Dispersed (2) | Low |
+
+### Quarantine debt (already quarantined, still severely broken)
+
+These tests have been quarantined but remain at critically low success rates — they have never been fixed.
+
+| Test | SIG | Worst Rate (7d) | Lanes Affected | Status |
+|------|-----|-----------------|----------------|--------|
+| [Cancel migration (delete source)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) | sig-compute/storage | **0.0%** | 4+ lanes | Deterministic regression — needs urgent investigation |
+| [Cancel migration (delete target)](https://github.com/kubevirt/kubevirt/blob/main/tests/migration/namespace.go#L595) | sig-compute/storage | **0.0%** | 4+ lanes | Deterministic regression — needs urgent investigation |
+| [USB 1 device](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L133) | sig-compute | 45.8–52.0% | 3 lanes | Long-standing, stable |
+| [USB 2 devices](https://github.com/kubevirt/kubevirt/blob/main/tests/usb/usb.go#L134) | sig-compute | 45.8–52.0% | 3 lanes | Long-standing, stable |
+| [VirtOperatorRESTErrorsBurst](https://github.com/kubevirt/kubevirt/blob/main/tests/monitoring/component_monitoring.go#L340) | sig-monitoring | 30.0% | 1 lane | Long-standing, stable |
+
+---
+
+## Suggested Follow-Up
+
+- **lane-failure-rate** on [periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute-migrations) — the cancel-migration tests dropped to 0% in 7d; deeper per-build analysis will confirm if this is a deterministic regression or correlated infra failure
+- **lane-failure-rate** on [periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok) — KWOK density tests worsened sharply; flip-rate analysis will distinguish regression from infra instability
+- **analyze-build** on recent failing builds from the k8s-1.36 presubmit lanes — high Pod-level failure rates (73-80%) suggest infrastructure issues worth root-causing


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds flake overview reports recently generated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new flake overview reports for 2026-06-22, 2026-06-24, and 2026-06-29.
  * Each report summarizes recent CI failure trends, highlights the most impacted areas, and includes lane-level breakdowns.
  * Added quarantine candidate summaries and follow-up suggestions to help identify where attention is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->