### PR TITLE
feat: adapt Claude skills to be usable with Gemini

### DIFF
--- a/.gemini/skills/analyze-build/SKILL.md
+++ b/.gemini/skills/analyze-build/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: analyze-build
+description: Analyze the root cause inside a failed prowjob when a user mentions a failure or adds a prowjob URL.
+argument-hint: <prowjob-url>
+allowed-tools: Read, Glob, Bash(go run *)
+---
+
+## Overview
+
+This skill helps the user to find the root cause and mitigations for failing prowjobs.
+
+It combines four analyses:
+1. **Build log analysis** — extracts error snippets from the build log and categorizes them
+2. **Kubernetes cluster state analysis** — downloads k8s-reporter artifacts (pods, nodes, events, VMIs) and detects infrastructure-level failures like CrashLoopBackOff, OOMKilled, NotReady nodes, failed migrations, and warning events
+3. **Etcd storage profiling** — if the job was run with `KUBEVIRT_PROFILE_ETCD=true`, downloads `etcd-storage-profile.json` from `artifacts/etcd-profiler/` and detects tmpfs exhaustion, tmpfs pressure, large WAL files, and DB growth trends
+4. **Container log analysis** — downloads virt-controller, virt-handler, virt-api, and virt-operator container logs from k8s-reporter suite artifacts for interactive grep
+
+## Analysis data generation
+
+As a base for analyzing the failure, the go tool `cmd/ci-failures` from the `kubevirt.io/ci-health` repository is to be used.
+
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
+
+Example how to generate the data files for a specific prowjob, given is the url to the prowjob build:
+
+```bash
+$ go run ./cmd/ci-failures analyze-build $ARGUMENTS
+```
+
+This produces up to two output files in a session directory:
+- `output/tmp/sessions/<session-id>/{job-name}.yaml` — build log error analysis
+- `output/tmp/sessions/<session-id>/k8s-analysis-{build-id}.yaml` — kubernetes cluster state analysis (if k8s-reporter artifacts exist), includes etcd profiler findings and full etcd profile data when available
+
+The tool logs each written file path. Extract the session directory from the first `"wrote analysis to ..."` or `"wrote k8s analysis to ..."` log line (e.g. `output/tmp/sessions/abc123/`).
+
+## Analysis
+
+### Infrastructure flake precheck
+
+Before diving into individual test failures, assess whether the entire build was an infrastructure flake:
+
+1. Count the number of distinct failed tests in the build log
+2. Check the k8s analysis (if present) for infrastructure-level problems: NotReady nodes, CrashLoopBackOff on system pods (virt-controller, virt-handler, virt-api, virt-operator), etcd issues (tmpfs exhaustion, large WAL)
+3. If **5 or more unrelated tests** failed AND **infrastructure findings** are present, classify the build as an **infrastructure flake** — the individual test failures are symptoms, not causes. Report the infra root cause and skip per-test analysis.
+4. If only a few tests failed or no infra findings exist, proceed with per-test analysis below.
+
+This avoids wasting time analyzing each test individually when the real problem is a bad node or a crashed component.
+
+### Quick flake check
+
+Consider suggesting the `test-failure-rate` skill on this build URL as a quick pre-filter. If all failing tests are already known flakes (success rate < 80% across lanes), the build failure is likely not actionable and the user can retrigger instead of investigating.
+
+### Detailed analysis
+
+After data generation:
+
+1. Extract the session directory path from the tool's log output, then list all `*.yaml` files in that directory
+2. Read the build log analysis YAML (`{job-name}.yaml`). The structure is:
+   - `job_name`: the Prow job name
+   - `build_errors`: list of build errors with `category`, `category_reason`, and `build_log_error_snippets`
+3. Read the k8s analysis YAML (`k8s-analysis-*.yaml`) if present. The structure is:
+   - `snapshots`: list of cluster state capture points (process + failure count)
+   - `findings`: list of detected issues, each with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`
+   - `summary`: aggregate counts by kind, severity, and detector
+   - `etcd_profile` (optional): full etcd storage profile with `peak_tmpfs_used_bytes`, `final_tmpfs_total_bytes`, `final_wal_size_bytes`, and per-spec `records` showing DB size deltas and tmpfs usage. Etcd-related findings use kind `EtcdProfile` and detectors `etcd-tmpfs-exhaustion`, `etcd-tmpfs-pressure`, `etcd-large-wal`, `etcd-db-growth`
+4. Read the container log files list from `container_log_files` in the k8s analysis YAML. Each entry has:
+   - `pod_name`, `container_name`, `namespace`: identify the component
+   - `cached_path`: local file path to grep
+   - `size_bytes`: file size
+5. **Cross-reference failing VMI/VM names against container logs**: extract VMI/VM names from build log errors (e.g. `testvmi-xxxxx`) and k8s findings (e.g. VMIs stuck in Scheduling), then use `grep` on the cached virt-controller and virt-handler logs to find why those VMIs failed. Common patterns to look for:
+   - Schema validation errors (e.g. `admission webhook` or `validation failed`)
+   - Sync failures (e.g. `syncError` or `failed to sync`)
+   - Device/resource issues (e.g. `device not found`, `resource not available`)
+   - Example: `grep -i "testvmi-xxxxx" <cached_path>` to find all log lines related to a specific VMI
+6. Correlate all analyses: k8s findings (e.g. CrashLoopBackOff on a component pod) often explain build log errors (e.g. test timeouts); etcd findings (e.g. tmpfs exhaustion) can explain node-level or apiserver issues; container log errors (e.g. schema validation failures in virt-controller) reveal the actual rejection reason when VMIs are stuck in non-Running phases
+7. Deduce the root cause and possible mitigations from the combined data
+
+## Suggested follow-up skills
+
+After the root-cause summary, suggest follow-up analyses when appropriate:
+- **test-failure-rate**: for test failures that might be flaky — checks historical success rates across all lanes and k8s versions to confirm whether the failure is a known flake or likely PR-related
+- **change-relevance**: for PR builds where test failures look PR-related — confirms whether the PR actually changed files in the failing test's code area
+- **trigger-pr-jobs**: when the failure is determined to be a flake or transient infrastructure issue — retriggers the failed job instead of investigating further

--- a/.gemini/skills/analyze-ci-failures/SKILL.md
+++ b/.gemini/skills/analyze-ci-failures/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: analyze-ci-failures
+description: Analyze root causes for all the recent CI failures (failing prowjobs that have not reached the testing stage).
+allowed-tools: Read, Write, Grep, Bash(go run *), Bash(stat *), Bash(ls *), Bash(git fetch *), Bash(git diff *)
+---
+
+## Overview
+
+This skill helps the user to find the root cause and mitigations for all ci failures aka failing prowjobs that have not reached the testing stage.
+
+## Analysis data generation
+
+As a base for analyzing the failure, the go tool `cmd/ci-failures` from the `kubevirt.io/ci-health` repository is to be used. As a base for the data the file
+`output/kubevirt/kubevirt/results.json` is used.
+
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
+
+Example how to generate the data files for the prowjobs failing ci:
+
+```bash
+$ go run ./cmd/ci-failures generate yaml
+```
+
+This produces:
+- `output/tmp/errors-{sig}/*.yaml` — per-job error extractions with snippets, line links, and context
+- `output/tmp/build-logs/{buildID}.yaml` — full cached build logs with prow URL, GCS URL, timestamps, and complete log content
+
+At the end of execution, the command prints a YAML list of all generated error files to stdout:
+```
+generated_files:
+  - output/tmp/errors-sig-compute/pull-kubevirt-e2e-k8s-1.35-sig-compute.yaml
+  - output/tmp/errors-sig-network/pull-kubevirt-e2e-k8s-1.35-sig-network.yaml
+  ...
+```
+Parse this list to know exactly which files to read — no separate file discovery step (find/glob) is needed.
+
+### Stale data
+Before you proceed, 
+1) check whether there's updates on `output/kubevirt/kubevirt/results.json` available on the main branch - in that case first update the current branch with latest changes by rebasing on main.
+2) compare `output/tmp` file time stamps with `output/kubevirt/kubevirt/results.json` - if the files in `output/tmp` are older than the latter, they are stale and need to get deleted.
+
+To compare timestamps, use `ls -lt` to list both files together — the newer file appears first:
+```bash
+$ ls -lt output/kubevirt/kubevirt/results.json output/tmp/errors-*/*.yaml
+```
+If `results.json` appears above (newer than) the error YAML files, the generated data is stale.
+
+To delete stale data, remove the entire `output/tmp` directory:
+```bash
+$ rm -rf output/tmp/*
+```
+
+## Data Available in the YAML Files
+
+### Error YAML files (`output/tmp/errors-{sig}/*.yaml`)
+
+Each file contains structured data — most metadata can be read directly without parsing URLs:
+
+- **SIG**: encoded in the parent directory name (e.g., `errors-sig-compute/`, `errors-sig-network/`, `errors-sig-storage/`, `errors-sig-monitoring/`, `errors-sig-performance/`)
+- **Job name** (`job_name` field): the Prow job name, e.g., `pull-kubevirt-e2e-k8s-1.35-sig-network`
+- **Branch**: deducible from `job_name` — if it ends with a version suffix like `-1.6`, it targets `release-1.6`; no suffix means `main`
+- **Kubernetes version**: deducible from `job_name` — the `k8s-X.Y` or `kind-X.Y` segment gives the K8s version (e.g., `1.35`)
+- **PR number**: deducible from `job_url` — the segment after `pull/kubevirt_kubevirt/` (e.g., `17129`)
+- **Build errors** (`build_errors` list), each containing:
+    - `job_url`: direct link to the Prow job UI
+    - `build_id`: the Prow build number (also usable to find the full build log)
+    - `started` / `finished`: timestamps
+    - `build_log_error_snippets`: list of extracted error matches, each with:
+        - `error_text`: the matched error line
+        - `context`: surrounding lines (typically 3 before and after) — this is the primary source for root cause analysis
+        - `link_to_log_line`: direct link to the error line in Prow UI
+        - `start_line`, `error_line`, `end_line`: line numbers in the build log
+
+### Full build log files (`output/tmp/build-logs/{buildID}.yaml`)
+
+Only needed when error snippets are insufficient for root cause analysis. Use the `show-log` command to read decoded build logs instead of reading the YAML files directly (they contain base64-encoded binary content):
+
+```bash
+# Show last 30 lines of a build log
+$ go run ./cmd/ci-failures show-log <build-id> --tail 30
+
+# Search for error patterns (case-insensitive)
+$ go run ./cmd/ci-failures show-log <build-id> --grep "error" --tail 20
+```
+
+Flags:
+- `--tail N` — print only the last N lines (default: all)
+- `--grep pattern` — filter lines containing the pattern (case-insensitive); output includes line numbers
+
+## Procedure
+
+1. **Use generated file list**: Parse the `generated_files:` YAML list printed by the `generate yaml` command to get all error YAML file paths — no separate discovery step needed
+2. **Read each error YAML file**: Extract the job name, SIG (from directory), and all build errors with their snippets
+3. **Analyze error snippets**: For each build error, examine `error_text` and `context` fields to determine root cause. In most cases the snippets contain enough information
+4. **Deep-dive when needed**: If snippets are ambiguous or empty, use `go run ./cmd/ci-failures show-log <build_id> --grep "error" --tail 20` to search the full build log
+5. **Classify** each failure as fixable or non-fixable
+6. **Group similar failures** across jobs — errors with the same root cause should be combined into a single group even if they appear in different SIGs or branches
+
+## Flakiness and infrastructure event detection
+
+After grouping failures by root cause, apply these additional analyses:
+
+### Cross-PR flake detection
+
+When the same test fails across multiple *different* PRs in the data, it is almost certainly a systemic flake, not caused by any individual PR. To identify these:
+
+1. After reading all error YAML files, collect failing test names across all jobs and PRs (extract PR number from `job_url`)
+2. Tests that appear in failures from 3+ different PRs are **quarantine candidates** — flag them prominently
+3. For these tests, the mitigation is quarantining the test, not fixing individual PRs
+
+### Infrastructure event detection
+
+When many errors from the same time window share infrastructure signatures, group them as a single infra event rather than analyzing each individually:
+
+1. Compare `started`/`finished` timestamps across build errors from different jobs
+2. If multiple unrelated jobs (different SIGs, different PRs) all failed within the same **2-4 hour window** with similar error patterns (e.g., registry pull failures, DNS timeouts, node provisioning failures), they likely hit the same infra event
+3. Group these as **"infra event at {time range}"** and describe the common infrastructure signature
+4. Common infra signatures to look for:
+   - Image pull errors (`ErrImagePull`, `ImagePullBackOff`) — registry or network issue
+   - Node provisioning failures — cloud provider issue
+   - DNS resolution failures — cluster DNS issue
+   - Timeout errors across many unrelated tests — general cluster instability
+   - `context deadline exceeded` in cluster setup — provisioning infra overloaded
+
+### Prioritization
+
+When presenting results, prioritize by actionability:
+1. **Cross-PR flakes** (quarantine candidates) — highest signal, immediately actionable
+2. **Infrastructure events** — not fixable by code changes, useful for incident tracking
+3. **Individual fixable failures** — specific to a PR or code change
+4. **Non-fixable/external failures** — lowest priority
+
+## Goal for analysis
+
+The output is to be looked at as described above, then reasons and possible mitigations are to be deduced.
+
+## Suggested follow-up skills
+
+After the CI failure summary, suggest follow-up analyses when appropriate:
+- **analyze-build**: for individual builds that need deeper investigation — deep-dives into cluster state (k8s-reporter artifacts, etcd profiling, container logs) to find infrastructure root causes beyond what error snippets reveal
+- **test-failure-rate**: for specific test failures that may be flaky — checks historical success rates across all lanes and k8s versions using flakefinder data
+- **flake-overview**: when the analysis reveals widespread flakiness across many lanes — provides a comprehensive cross-lane view combining flakefinder and testgrid data with quarantine prioritization

--- a/.gemini/skills/analyze-pr-builds/SKILL.md
+++ b/.gemini/skills/analyze-pr-builds/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: analyze-pr-builds
+description: Analyze all failed builds for a GitHub pull request and identify root causes.
+argument-hint: <pr-url>
+allowed-tools: Read, Bash(go run *), Grep
+---
+
+## Overview
+
+This skill analyzes all currently-failing builds for a GitHub pull request, identifies root causes, and presents a concise summary.
+
+It works for any repo served by prow.ci.kubevirt.io (currently the `kubevirt` GitHub org).
+
+## Data Generation
+
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
+
+Two commands to run sequentially:
+
+### Step 1: Fetch and analyze all failed builds
+
+```bash
+$ go run ./cmd/ci-failures analyze-pr $ARGUMENTS
+```
+
+This downloads build logs, k8s-reporter artifacts, and container logs for every currently-failing job in the PR. Output files go to the session directory.
+
+### Step 2: Get a condensed summary
+
+```bash
+$ go run ./cmd/ci-failures summarize-session
+```
+
+This reads all session YAML files and emits a **single condensed YAML** to stdout containing just the key fields needed for analysis. This replaces the need to read individual files.
+
+## Analysis
+
+After running both commands:
+
+1. Read the `summarize-session` stdout output. The structure is:
+   - `jobs`: list of failed jobs, each with:
+     - `job_name`: the Prow job name
+     - `job_url`: link to the Prow job UI
+     - `build_id`: the build number
+     - `category`: error category (external, internal, pr-build, needs-investigation)
+     - `category_reason`: explanation of the categorization
+     - `error_snippets`: list of `{error_text, link}` — one-line error text and link to the log line
+   - `k8s_analyses`: list of k8s analysis results per build, each with:
+     - `build_id`, `job_name`, `total_findings`
+     - `findings`: list of `{detector, severity, kind, namespace, name, reason, message}`
+     - `container_log_files`: list of `{pod_name, container_name, namespace, cached_path, size_bytes}` for grep cross-referencing
+2. **Cross-reference failing VMI/VM names against container logs**: extract VMI/VM names from error snippets and k8s findings, then use `grep` on the cached virt-controller and virt-handler logs to find the actual rejection reason. Example: `grep -i "testvmi-xxxxx" <cached_path>`
+3. Correlate findings across all sources — e.g. CrashLoopBackOff on a component pod often explains test timeouts; etcd tmpfs exhaustion can explain apiserver failures; virt-controller log errors (schema validation, sync failures) reveal why VMIs are stuck in non-Running phases
+4. Group failures with the same root cause together
+
+## Cross-job failure correlation
+
+Before presenting results, analyze how failures correlate across jobs to distinguish PR-related issues from flakes and infra events:
+
+### Same test failing across multiple jobs
+When the same test fails in multiple different jobs for this PR, it strengthens the "PR-related" signal — the PR likely broke something that is exercised across environments. This is especially strong when the test passes consistently in periodic lanes but fails in all of this PR's presubmit runs.
+
+### Different tests failing in different jobs with no overlap
+When each job has different failures with no common tests, suspect independent flakes or separate infra events rather than a PR-caused issue. No single code change typically causes unrelated tests to fail in unrelated ways.
+
+### Multiple unrelated tests failing in the same job
+When many unrelated tests fail together in a single job but pass in other jobs, suspect an infrastructure flake in that specific run — node issues, network blips, storage problems. Check the k8s analysis for that build for corroborating evidence (NotReady nodes, CrashLoopBackOff, etcd issues).
+
+### Consistent failure across retries
+If the PR has been retried and the same tests fail every time, it's almost certainly PR-related. If different tests fail on each retry, it's flaky infrastructure.
+
+## Output
+
+Present a concise summary to the user:
+- Group failures by root cause
+- For each group: state the root cause, list affected jobs, and include one representative error snippet
+- Include relevant k8s findings that explain or contribute to the failure
+- Note the **cross-job pattern** for each group: appears in all jobs (likely PR-caused), appears in one job only (possible flake), or correlates with infra findings (infra flake)
+- Classify each as **fixable** (CI config or code issue) or **non-fixable** (external/infra)
+- Include the `link` for the most relevant error in each group
+
+## Suggested follow-up skills
+
+After the root-cause summary, suggest follow-up analyses when appropriate:
+- **test-failure-rate**: for failures that look flaky — confirms whether the test has a history of flakiness across all lanes and k8s versions
+- **change-relevance**: for failures that look PR-related — confirms whether the PR actually changed files in the test's code area
+- **lane-failure-rate**: for failures concentrated in one job/lane — shows whether that lane is generally unhealthy

--- a/.gemini/skills/change-relevance/SKILL.md
+++ b/.gemini/skills/change-relevance/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: change-relevance
+description: Determine whether a PR's code changes are related to tests that failed in a Prow build.
+argument-hint: <prow-job-url>
+allowed-tools: Read, Glob, Bash(go run *)
+---
+
+## Overview
+
+This skill checks whether a PR's changed files overlap with the code areas that failing tests cover. It extracts the PR number from the Prow job URL, fetches the changed files from GitHub, maps each failed test to source directories via its SIG label, and reports whether the changes are related.
+
+## Data generation
+
+Run the `change-relevance` subcommand with a Prow job URL for a **PR build**:
+
+```bash
+$ go run ./cmd/ci-failures change-relevance $ARGUMENTS
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures change-relevance $ARGUMENTS
+```
+
+This produces `output/tmp/change-relevance-{job-name}.yaml`.
+
+Only PR builds (URLs containing `pr-logs/pull/`) are supported. Periodic builds will return an error.
+
+## Analysis
+
+After data generation:
+
+1. Use Glob to find the `output/tmp/change-relevance-*.yaml` file
+2. Read the YAML. The structure is:
+   - `prow_job_url`: the analyzed build URL
+   - `job_name`: the Prow job name
+   - `org`, `repo`, `pr_number`: the GitHub PR identity
+   - `changed_files`: list of files changed in the PR
+   - `failed_tests`: list of failed tests, each with:
+     - `test_name`: original test name from the build log
+     - `sig`: the SIG label extracted from the test name (or inferred from job name)
+     - `code_areas`: source directory prefixes mapped to that SIG
+     - `overlap_files`: PR files that overlap with the test's code areas (empty if none)
+     - `relevance`: classification of the relationship
+     - `reason`: human-readable explanation
+   - `summary`: aggregate counts of each relevance level
+
+## Relevance classification
+
+- **related**: The PR directly changes files in the SIG's code areas. The test failure is likely caused by the PR.
+- **possibly-related**: The PR changes broad-impact files (API definitions, shared utilities, test framework) that could affect any test. Cannot rule out the PR as the cause.
+- **unrelated**: The PR does not change any files in the test's code areas or in broad-impact areas. The failure is likely a pre-existing flake.
+- **unknown**: The test has no SIG label and the SIG could not be inferred from the job name, or the SIG is not in the mapping.
+
+## Presenting results
+
+For each failed test, report:
+1. The test name
+2. The SIG and relevance classification
+3. If related or possibly-related, list the overlapping files
+4. If unrelated, note that the failure is likely a flake
+
+Summarize with the aggregate counts from the `summary` section.
+
+## Combining with test-failure-rate
+
+For the most complete picture, run both `change-relevance` and `test-rate` on the same Prow job URL. Together they answer:
+- **test-rate**: Is this test historically flaky? Are failures dispersed or concentrated?
+- **change-relevance**: Did this PR touch the code the test covers?
+
+### Decision matrix
+
+Use this matrix to combine signals from both skills for a definitive assessment:
+
+| test-rate severity | change-relevance | failure pattern | verdict |
+|---|---|---|---|
+| likely-pr-related | related | concentrated in PR lane | **PR-caused** — the PR broke this test |
+| likely-pr-related | possibly-related | concentrated in PR lane | **likely PR-caused** — broad-impact files changed, test rarely fails |
+| likely-pr-related | unrelated | concentrated in PR lane | **suspicious** — test almost never fails but PR didn't touch its area; check for indirect dependencies |
+| inconclusive | related | dispersed | **investigate** — PR touches the area but the test has some flake history |
+| inconclusive | unrelated | dispersed | **likely flake** — moderate flakiness and PR doesn't touch the area |
+| likely-flaky | unrelated | dispersed | **flake — ignore** — known flake, PR is irrelevant |
+| likely-flaky | related | dispersed | **flake despite overlap** — the test flakes regardless of changes; PR overlap is coincidental |
+| likely-flaky | any | infra-correlated | **infra flake** — fails alongside unrelated tests in same lanes |
+| unknown | related | n/a | **investigate** — test may be new or renamed, but PR touches the area |
+| unknown | unrelated | n/a | **likely new test or flake** — not in flakefinder, PR doesn't touch the area |
+
+The **failure pattern** column comes from test-rate's dispersion analysis (dispersed = fails across many lanes, concentrated = fails in few lanes, infra-correlated = fails alongside unrelated tests).

--- a/.gemini/skills/flake-overview/SKILL.md
+++ b/.gemini/skills/flake-overview/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: flake-overview
+description: Provide a unified flake analysis combining GCS-based flakefinder reports with testgrid success rates.
+allowed-tools: Read, Write, Bash(go run *), Bash(find *), Bash(ls *), Bash(test *), Grep
+---
+
+## Overview
+
+This skill runs a single command that combines two complementary views of test flakiness:
+
+1. **flakefinder data** — aggregates 24h flakefinder reports from GCS, showing which lanes have the most test failures across PRs
+2. **lane-rate data** — for each lane, fetches testgrid data directly and computes per-test failure rates
+
+Together they answer: "which tests are flaky, is it a PR-interaction problem or a baseline issue, and is it getting better or worse?"
+
+## Step 1: Locate the ci-health repository and run flake-overview twice
+
+The `cmd/ci-failures` tool lives in the `kubevirt.io/ci-health` repository. If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
+
+Run the command twice — once for a 28-day window and once for a 7-day window — to enable trend detection:
+
+```bash
+go run ./cmd/ci-failures flake-overview --days 28
+```
+
+Read the output YAML, then run:
+
+```bash
+go run ./cmd/ci-failures flake-overview --days 7
+```
+
+Read that output YAML too. Both runs produce a file at `output/tmp/flake-overview.yaml` (or `output/tmp/sessions/{session-id}/flake-overview.yaml` when a session ID is set). The second run overwrites the first, so read the first output before running the second.
+
+The command:
+1. Fetches flakefinder 24h reports from GCS for the requested window
+2. Aggregates per-lane failure counts (filtering out `.*-root$` lanes by default)
+3. For each lane, fetches testgrid data and computes per-test success rates (6 lanes in parallel)
+4. Combines everything into a single YAML
+
+## Step 2: Read and cross-reference both outputs
+
+Use the 28-day data as the baseline and the 7-day data for trend detection. For each test, compare:
+
+- **7d rate similar to 28d**: long-standing flake — quarantine is warranted
+- **7d rate much worse than 28d**: flakiness is worsening — possible recent regression, investigate recent merges
+- **7d rate much better than 28d**: flakiness is improving — a fix may have landed recently, quarantine may not be needed
+
+### YAML structure
+
+```yaml
+report_date: "2026-05-13"
+analysis_days: 14
+total_failures: 1207
+lanes:
+  - name: periodic-kubevirt-e2e-k8s-1.36-sig-compute
+    url: https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute
+    failures: 348
+    share_percent: 28.83
+    total_builds: 56
+    failed_tests:
+      - test_name: "full test description"
+        succeeded: 0
+        failed: 55
+        skipped: 1
+        total_runs: 55
+        success_rate: 0.0
+        severity: likely-flaky
+        recent_failures:
+          - build_id: "2054504557802688512"
+            timestamp: "2026-05-13T10:11:03Z"
+            message: "error message excerpt..."
+```
+
+Key fields:
+- `total_failures` — total failures across all lanes in the window
+- `lanes[*].failures` — flakefinder failure count for this lane
+- `lanes[*].share_percent` — percentage of total failures
+- `lanes[*].total_builds` — number of testgrid builds analyzed
+- `lanes[*].failed_tests` — per-test failure data from testgrid
+- `failed_tests[*].success_rate` — percentage (0-100)
+- `failed_tests[*].severity` — likely-pr-related (>=95%), inconclusive (>=80%), likely-flaky (<80%)
+
+## Deeper flakiness analysis
+
+The severity classification and success rates are a starting point. Apply these techniques to the data for more accurate diagnosis.
+
+### Flip-rate analysis from recent_failures
+
+Examine the `recent_failures` list for each test to detect state transition patterns:
+
+- **High flip rate** (failures interleaved with passes, spread across the time window): genuine flake — the test is nondeterministic
+- **Low flip rate** (failures clustered consecutively): the test was broken for a period then fixed, or is still broken — this is a regression, not a flake
+- **Key heuristic**: 3 or more consecutive failures should be treated as deterministic breakage, not flakiness. A test at 60% success rate with alternating pass/fail is very different from one that failed for a solid week then passed for a solid week — same rate, completely different diagnosis.
+
+### Cross-lane dispersion
+
+Collect all failing test names across all lanes and categorize by how many lanes they appear in:
+
+- **Dispersed** (fails in 3+ lanes): genuine cross-environment flake — strong quarantine candidate regardless of success rate
+- **Concentrated** (1–2 lanes only): lane-specific issue — check whether those lanes share a k8s version, provider, or SIG. The test itself may be fine; the environment is the problem.
+- **Universal** (fails in every or nearly every lane): likely a regression on main, not a flake — check if it was recently introduced by looking at whether recent_failures timestamps cluster near the present
+
+### Infra-correlated failure detection
+
+Within each lane, compare `build_id`s across different failing tests:
+
+- When multiple unrelated tests share the same `build_id`s in their `recent_failures`, they failed together in the same builds — this is an infrastructure flake at the lane level, not individual test problems
+- If a small number of builds account for most failures across many tests in a lane, the lane experienced infra instability during those builds
+- Flag these as **infra-correlated** — these tests should NOT be quarantined; the lane's infrastructure should be investigated instead
+
+## Quarantine prioritization
+
+When identifying quarantine candidates, rank by these criteria (not just success rate):
+
+1. **High priority**: dispersed across 3+ lanes + high flip rate + low success rate — genuine cross-environment flake causing widespread CI noise
+2. **Medium priority**: concentrated in 1–2 lanes + low success rate — lane-specific issue, may resolve with infra changes but still wastes CI capacity
+3. **Low priority**: burst pattern or consecutive failures — transient, may already be resolved; verify with trend detection before quarantining
+4. **Not a quarantine candidate**: infra-correlated (many tests failing together in same builds within a lane) — quarantining individual tests won't help; the lane needs investigation
+
+## Step 3: Resolve test source locations
+
+For each unique failing test, find its source file and line number so the report can link directly to the code. This helps readers who are not familiar with the test codebase.
+
+1. **Locate the kubevirt/kubevirt repo**: look for `kubevirt.io/kubevirt` (or `kubevirt/kubevirt`) relative to the ci-health repo's parent directory.
+2. **Extract the `It("...")` description** from each test name. The test name is a concatenation of Ginkgo `Describe`/`Context`/`It` blocks separated by spaces. The `It` text is the last meaningful segment — typically everything after the last known context boundary. For example:
+   - Full name: `KubeVirt Tests Suite.[sig-compute]VSOCK Live migration should retain the CID for migration target`
+   - Search string: `should retain the CID for migration target`
+3. **Grep for the description** in the `tests/` directory: `grep -rn "<description>" tests/ --include="*.go"`
+4. **Construct a GitHub permalink**: `https://github.com/kubevirt/kubevirt/blob/main/<path>#L<line>` (e.g., `https://github.com/kubevirt/kubevirt/blob/main/tests/vmi_vsock_test.go#L121`)
+
+If the kubevirt repo is not available locally, skip this step — the report will still be useful without links, just less navigable.
+
+Skip `.Pod` and `BeforeSuite`/`AfterSuite` entries — these are infrastructure-level, not test code.
+
+## Presenting results
+
+Always write the report to `output/kubevirt/kubevirt/flake-overview/flake-overview-YYYY-MM-DD.md`. The reports are long and structured — a file is easier to read, share, and diff against future runs than inline output.
+
+The report must be **grouped by SIG** (derived from lane names: `sig-compute`, `sig-storage`, `sig-network`, `sig-operator`, `sig-monitoring`, `sig-performance`). Lanes that don't match a SIG (e.g., S390X, arm64) go under a "Platform-specific" group.
+
+### Report structure
+
+#### 1. Summary section (top of report)
+
+Lead with a concise summary covering:
+
+- Report date and analysis windows (28d and 7d)
+- Total failures and number of lanes for each window
+- Overall trend (improving / stable / worsening) based on 7d-vs-28d proportional comparison
+- Top 3 worst SIGs by total failure count
+- Number of quarantine candidates identified (high / medium / low priority)
+- Number of infra-unstable lanes
+
+Add a **navigation links** section immediately after the summary with markdown anchor links to each SIG section, e.g.:
+
+```markdown
+## Navigation
+
+- [sig-compute](#sig-compute)
+- [sig-storage](#sig-storage)
+- [sig-network](#sig-network)
+- [sig-operator](#sig-operator)
+- [sig-monitoring](#sig-monitoring)
+- [sig-performance](#sig-performance)
+- [Platform-specific](#platform-specific)
+- [Infrastructure](#infrastructure)
+- [Quarantine Candidate Summary](#quarantine-candidate-summary)
+```
+
+#### 2. Infrastructure section
+
+Before the SIG sections, flag infra-correlated lanes:
+
+- Presubmit Pod-level failure rates (all lanes with `.Pod` failures)
+- Lanes with complete setup failures (BeforeSuite/AfterSuite at 0%)
+- Include 28d-vs-7d trend for infra health
+
+#### 3. Per-SIG sections
+
+For each SIG, create a section with:
+
+- **SIG header** with total failures and failure share across all lanes in that SIG
+- **Lanes table**: list all lanes for this SIG with failures, share, builds, and 28d-vs-7d trend
+- **Failing tests table** for each lane, sorted by success rate (worst first). For each test include:
+  - Test name as a **markdown link to the source code** (GitHub permalink from Step 3). If no source link was resolved, use the plain test name.
+  - Success rate (28d and 7d), total runs, and severity
+  - **Trend**: arrow or label indicating direction (28d→7d)
+  - **Dispersion**: how many lanes this test fails in (dispersed / concentrated / universal)
+  - **Pattern**: flaky (high flip rate), burst (clustered timestamps), consecutive (deterministic), or infra-correlated
+  - `[QUARANTINE]` flag if present in the test name
+
+#### 4. Quarantine candidate summary (bottom of report)
+
+After all SIG sections, provide a cross-SIG quarantine candidate table:
+
+| Test | SIG | Lanes | Worst Rate (28d) | 7d Trend | Pattern | Dispersion | Priority |
+|------|-----|-------|-------------------|----------|---------|------------|----------|
+
+Where:
+- **Test** is a markdown link to the source code (GitHub permalink from Step 3)
+- **Priority** is high/medium/low/not-candidate per the quarantine prioritization criteria
+- **7d Trend** is improving/stable/worsening with the rate delta
+- Only include non-quarantined tests (exclude those already tagged `[QUARANTINE]`)
+
+Then list already-quarantined tests that remain severely broken (success rate <50%) as a "quarantine debt" reminder — these have been quarantined but never fixed. These should also link to source code.
+
+## Suggested follow-up skills
+
+After the flake overview report, suggest follow-up analyses when appropriate:
+- **lane-failure-rate**: for lanes with high failure counts or suspected infrastructure instability — provides deeper per-lane analysis with flip-rate, burst detection, and cross-test correlation on a specific lane
+- **analyze-build**: for specific failing builds identified during the overview — deep-dives into cluster state (k8s-reporter artifacts, etcd profiling, container logs) to distinguish infrastructure issues from test-level flakiness

--- a/.gemini/skills/lane-failure-rate/SKILL.md
+++ b/.gemini/skills/lane-failure-rate/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: lane-failure-rate
+description: Analyze failure rates, flip-rates, and flakiness patterns for all tests in a testgrid lane.
+argument-hint: <testgrid-url>
+allowed-tools: Read, Glob, Bash(go run *), Bash(gh *)
+---
+
+## Overview
+
+This skill analyzes a testgrid lane and calculates failure rates for every test that has at least one failure in the requested time window. Unlike test-failure-rate (which starts from a single build's failed tests and looks them up in flakefinder), this skill operates at the lane level — it fetches all test results directly from testgrid and computes rates from raw pass/fail data.
+
+## Lane discovery
+
+When the user asks to analyze lanes for a Kubernetes version (e.g. "kubevirt 1.36 lanes") without providing specific testgrid URLs, use the `discover-lanes` subcommand to find all matching lanes across both periodic and presubmit dashboards.
+
+```bash
+$ go run ./cmd/ci-failures discover-lanes $ARGUMENTS
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures discover-lanes $ARGUMENTS
+```
+
+This queries the testgrid summary API for both `kubevirt-periodics` and `kubevirt-presubmits` dashboards and produces `output/tmp/discover-lanes-{version}.yaml`.
+
+### Discovery output YAML structure
+
+```yaml
+version_filter: "1.36"
+dashboards:
+  - name: kubevirt-periodics
+    lanes:
+      - tab: periodic-kubevirt-e2e-k8s-1.36-sig-compute
+        overall_status: FAILING
+        testgrid_url: "https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.36-sig-compute"
+  - name: kubevirt-presubmits
+    lanes:
+      - tab: pull-kubevirt-e2e-k8s-1.36-sig-compute
+        overall_status: FLAKY
+        testgrid_url: "https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.36-sig-compute"
+```
+
+Note: some SIG lanes only exist on one dashboard (e.g. `sig-compute-serial` is presubmit-only).
+
+### Specialized presubmit lanes
+
+Presubmits often include specialized lanes beyond the standard SIG lanes — for specific architectures (e.g. `sig-compute-arm64`), subsets (e.g. `sig-compute-windows`), or serial execution (`sig-compute-serial`). These lanes typically do **not** have periodic counterparts. However, the tests they run usually also exist in the standard SIG lane of the same type (e.g. an arm64-specific test failure may also appear in the regular `sig-compute` periodic lane). When cross-referencing failures, check the standard SIG lane for the same test name even if the specialized lane has no periodic equivalent.
+
+### Workflow for multi-lane analysis
+
+1. Run `discover-lanes` to find all matching lanes
+2. Read the discovery YAML to get testgrid URLs
+3. Run `lane-rate` for each discovered lane (can run in parallel), using the `testgrid_url` from the discovery output
+4. Analyze and present results across all lanes, noting cross-lane patterns
+
+### Interpreting periodic vs presubmit data
+
+- **Periodic lanes** run on a fixed schedule against the latest merged code. Failures here indicate problems in mainline — they affect everyone.
+- **Presubmit lanes** run against unmerged PR code. Failures may be caused by individual PR changes, so the baseline failure rate is noisier. However, tests that fail consistently in presubmits with high volume are strong flake signals.
+- When a test fails in **both** periodic and presubmit lanes, it's almost certainly a real issue in mainline (not PR-caused).
+- When a test fails **only** in presubmits, it may be a genuine flake that's easier to trigger under presubmit conditions (different concurrency, resource pressure, timing).
+
+## Data generation
+
+Run the `lane-rate` subcommand from the `kubevirt.io/ci-health` repository with a testgrid URL.
+
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
+
+```bash
+$ go run ./cmd/ci-failures lane-rate $ARGUMENTS
+```
+
+To control the analysis window (default 14 days):
+
+```bash
+$ go run ./cmd/ci-failures lane-rate --days 21 $ARGUMENTS
+```
+
+To filter out one-off failures and only keep tests at or below a success rate threshold (useful for noisy presubmit lanes):
+
+```bash
+$ go run ./cmd/ci-failures lane-rate --max-success-rate 95 $ARGUMENTS
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures lane-rate $ARGUMENTS
+```
+
+This produces `output/tmp/lane-rate-{tab-name}.yaml`.
+
+When analyzing presubmit lanes (which typically have many one-off test failures from individual PRs), use `--max-success-rate 95` to focus on tests with meaningful failure patterns.
+
+## Analysis
+
+After data generation:
+
+1. Use Glob to find the `output/tmp/lane-rate-*.yaml` file
+2. Read the YAML. The structure is:
+   - `testgrid_url`: the original testgrid URL analyzed
+   - `dashboard`: the testgrid dashboard name (e.g., "kubevirt-periodics")
+   - `tab`: the testgrid tab/lane name (e.g., "periodic-kubevirt-e2e-k8s-1.36-sig-storage")
+   - `report_days`: number of days covered
+   - `report_period_start`: start of the analysis window (ISO 8601)
+   - `report_period_end`: end of the analysis window (ISO 8601)
+   - `total_builds`: number of builds in the analysis window
+   - `failed_tests`: list of tests with at least one failure, sorted by success rate ascending (worst first), each with:
+     - `test_name`: full test name from testgrid
+     - `succeeded`: number of passing runs
+     - `failed`: number of failing runs (includes flaky runs)
+     - `skipped`: number of skipped/not-run entries
+     - `total_runs`: succeeded + failed (excludes skipped)
+     - `success_rate`: percentage (0-100)
+     - `severity`: classification of the failure pattern
+     - `recent_failures`: up to 10 most recent failures, each with:
+       - `build_id`: the build/column identifier
+       - `timestamp`: ISO 8601 timestamp of the build
+       - `message`: failure message from testgrid (may be empty)
+
+## Severity classification
+
+- **likely-pr-related** (success rate >= 95%): rare failure, likely a one-off
+- **inconclusive** (success rate >= 80%): moderate failure rate, needs investigation
+- **likely-flaky** (success rate < 80%): frequent failures, likely a known flake
+- **unknown**: no pass+fail data available
+
+## Deeper flakiness analysis
+
+The severity classification above is based on aggregate success rate. Use the `recent_failures` data to perform richer pattern analysis that better distinguishes genuine flakes from deterministic breakage and infrastructure events.
+
+### Flip-rate analysis
+
+Examine the `recent_failures` list to detect state transitions (pass→fail→pass patterns):
+
+- **High flip rate** (failures interleaved with passes, spread across the window): the test is nondeterministic — a genuine flake
+- **Low flip rate** (failures clustered consecutively): the test was broken for a period then fixed, or is still broken — not a flake but a regression
+- **Key heuristic**: 3 or more consecutive failures should be treated as deterministic breakage, not flakiness (per Google testing research). When all `recent_failures` timestamps are consecutive builds, the test has a real bug regardless of what the aggregate success rate says
+
+A test with 75% success rate could be either: flaky (alternating pass/fail across 40 runs) or broken-then-fixed (failed 10 runs in a row then passed 30). The flip rate distinguishes the two — same success rate, completely different diagnosis.
+
+### Burst detection
+
+Examine the timestamps in `recent_failures`:
+
+- **Clustered failures** (many failures in a short time window, e.g. several within the same day): likely an infrastructure event, a temporary regression, or a bad merge that was later reverted
+- **Spread failures** (failures distributed evenly across the analysis window): genuine flaky behavior — the test fails randomly regardless of external factors
+- **Single burst then clean**: a transient event — the test is healthy now despite the lower success rate
+
+### Cross-test infrastructure flake detection
+
+Compare `recent_failures` timestamps across different tests in the results:
+
+- When multiple unrelated tests share the same failure timestamps (same `build_id`s), they failed together in the same build — this is an infrastructure flake signal, not individual test problems
+- Group tests that share failure timestamps and flag them as **infra-correlated**
+- Common infra patterns: node instability, storage backend issues, registry pull failures, network flakes — these cause unrelated tests to fail simultaneously
+- If a small number of builds account for most failures across many tests, the lane experienced infra instability during those builds
+
+## Presenting results
+
+1. Lead with a summary: total builds analyzed, number of tests with failures
+2. **Flag infra-correlated failures first**: if multiple tests share failure timestamps, group them and note the affected build IDs — these are lane-level problems, not test-level
+3. Group remaining tests by severity, starting with the worst (likely-flaky)
+4. For each test, report:
+   - Test name, success rate, total runs, and severity
+   - **Failure pattern**: flaky (high flip rate, spread), burst (clustered), consecutive (deterministic), or infra-correlated
+   - Most recent failure messages for tests with low success rates
+5. Note the total builds count to contextualize rates — a test that failed 1/2 is different from 1/42
+6. Tests tagged `[QUARANTINE]` are already known flakes; note this when presenting
+7. **Quarantine transitions**: a test may be quarantined or unquarantined during the observation period. When this happens, the results show two entries for the same underlying test — one with `[QUARANTINE]` in the name and one without — each covering only the portion of the window where that variant was active. Treat these as a single test: combine their failure counts mentally, and note the transition (e.g. "quarantined mid-window, 0/45 before + 0/6 after"). A high skip count on one variant and low skip count on the other is the telltale sign of a mid-window quarantine change.
+
+### Summary table
+
+After per-test details, provide a summary:
+
+| Test | Rate | Runs | Pattern | Assessment |
+|------|------|------|---------|------------|
+
+Where **Pattern** is one of:
+- **flaky** — high flip rate, failures spread across time (genuine flake)
+- **burst** — failures clustered in a short time window (transient event)
+- **consecutive** — 3+ failures in a row (deterministic breakage)
+- **infra-correlated** — fails alongside other unrelated tests in same builds
+
+## Issue tracking
+
+After presenting the analysis and top priorities, check GitHub for existing tracker issues and offer to create missing ones.
+
+### Searching for existing issues
+
+For each top-priority test failure, search the upstream repository (typically `kubevirt/kubevirt`) for open issues that reference the test name or a distinctive keyword from the error message:
+
+```bash
+gh issue list -R kubevirt/kubevirt --state open --search "virtiofs ServiceAccount token" --limit 5
+```
+
+Use a short, distinctive substring of the test name — not the full name, which is too long for search. Try the most specific part (e.g. `virtiofs ServiceAccount`, `should pause VMI on IO error`, `volume migrate block to filesystem`). If no results, try the error signature (e.g. `expired after 200 seconds config.go:173`).
+
+### Presenting results
+
+For each top-priority item, report whether a tracking issue exists:
+- **Found**: link the issue (number + title)
+- **Not found**: note that no existing issue was found
+
+After the search results, offer to create GitHub issues for any top-priority failures that lack a tracker. Do not create issues automatically — ask the user first. When creating, include:
+- Test name and lane(s) affected
+- Success rate and time window
+- Failure pattern (consecutive, flaky, infra-correlated)
+- Error message snippet
+- Testgrid link(s)
+
+## Opaque lanes (missing JUnit data)
+
+Some lanes — typically unit test lanes on non-Bazel architectures (e.g. s390x) — do not produce JUnit XML artifacts. When this happens, testgrid only has two entries:
+
+```
+{lane-name}.Overall
+{lane-name}.Pod
+```
+
+### Detecting opaque lanes
+
+After running `lane-rate`, check whether the `failed_tests` list contains only entries ending in `.Overall` or `.Pod` (or is empty despite the lane having a non-zero failure rate in testgrid). If so, the lane is opaque — all failures are collapsed into a single `.Pod` entry, and per-test analysis is meaningless.
+
+### What to do with opaque lanes
+
+1. **Flag the limitation**: tell the user that this lane lacks per-test JUnit data, so lane-rate analysis cannot distinguish individual test failures. The aggregate failure rate is still valid, but per-test breakdown is not.
+2. **Suggest manual build analysis**: use the `analyze-build` skill on individual failing builds to identify specific test failures from the raw build log.
+3. **Root cause**: KubeVirt unit tests use Ginkgo with a shared `KubeVirtTestSuiteSetup` function (`staging/src/kubevirt.io/client-go/testutils/setup.go`) that already supports JUnit XML via `v1reporter.NewV1JUnitReporter`, but the reporter is only activated under Bazel environment variables (`GO_TEST_WRAP`, `XML_OUTPUT_FILE`). Non-Bazel test paths (like `make go-test` used by s390x) skip JUnit output because these env vars are absent. The fix is to enable the Ginkgo JUnit reporter when the `ARTIFACTS` env var is set (which Prow provides).
+4. **Link to tracking issue**: https://github.com/kubevirt/kubevirt/issues/18225
+
+## Combining with test-failure-rate
+
+The `lane-rate` command gives a lane-wide overview, while `test-failure-rate` gives a cross-lane view for specific tests. Use `lane-rate` to find which tests are problematic in a lane, then use `test-failure-rate` on a specific build to see if those tests also fail in other lanes.

--- a/.gemini/skills/test-failure-rate/SKILL.md
+++ b/.gemini/skills/test-failure-rate/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: test-failure-rate
+description: Analyze test failures from a Prow build against historical 7-to-28 day flakefinder reports.
+argument-hint: <prow-job-url>
+allowed-tools: Read, Glob, Bash(go run *)
+---
+
+## Overview
+
+This skill looks up the historical success rate for each test that failed in a Prow build, using kubevirt flakefinder 7-day (168h) reports. Use `--days` to extend the analysis window up to 28 days by fetching and merging multiple weekly reports.
+
+## Data generation
+
+Run the `test-rate` subcommand from the `kubevirt.io/ci-health` repository with the Prow job URL.
+
+If not already inside the `ci-health` repository, `cd` into it first (e.g. `cd kubevirt.io/ci-health` from the `github.com` directory).
+
+```bash
+$ go run ./cmd/ci-failures test-rate $ARGUMENTS
+```
+
+To cover a longer period (up to 28 days):
+
+```bash
+$ go run ./cmd/ci-failures test-rate --days 14 <prow-job-url>
+```
+
+Example:
+
+```bash
+$ go run ./cmd/ci-failures test-rate $ARGUMENTS
+```
+
+This produces `output/tmp/sessions/<session-id>/test-rate-{job-name}.yaml`.
+
+The tool logs the written file path. Extract the session directory from the `"wrote test rate analysis to ..."` log line.
+
+## Analysis
+
+After data generation:
+
+1. Extract the session directory path from the tool's log output, then find the `test-rate-*.yaml` file in that directory
+2. Read the YAML. The structure is:
+   - `prow_job_url`: the analyzed build URL
+   - `job_name`: the Prow job name
+   - `report_days`: number of days covered
+   - `report_period_start`: start date of the merged flakefinder window
+   - `report_period_end`: end date of the merged flakefinder window
+   - `failed_tests`: list of failed tests, each with:
+     - `test_name`: original test name from the build log
+     - `matched_name`: the matching test name in the flakefinder report (empty if no match)
+     - `total_succeeded`: total successes across all jobs in the covered period
+     - `total_failed`: total failures across all jobs
+     - `total_skipped`: total skips
+     - `success_rate`: percentage (0-100)
+     - `severity`: classification of the failure
+     - `k8s_versions`: per-Kubernetes-version breakdown, sorted by success rate ascending (worst first), each with:
+       - `version`: Kubernetes version (e.g., "1.35", "1.36", or "unknown")
+       - `succeeded`, `failed`, `skipped`: counts aggregated across all lanes for this version
+       - `success_rate`: percentage (0-100)
+       - `severity`: classification for this version
+       - `lanes`: per-lane breakdown within this version, sorted by success rate ascending, each with:
+         - `lane`: job name
+         - `succeeded`, `failed`, `skipped`: counts for this lane
+         - `success_rate`: percentage (0-100)
+         - `severity`: classification for this lane
+
+## Severity classification
+
+- **likely-pr-related** (success rate >= 95%): the test almost always passes, so this failure is probably caused by the PR's changes
+- **inconclusive** (success rate >= 80%): moderate flakiness, can't determine if PR-related
+- **likely-flaky** (success rate < 80%): the test fails frequently across all jobs, likely a known flake
+- **unknown**: the test was not found in the flakefinder report
+
+## Deeper flakiness analysis
+
+The severity classification above is a starting point. Success rate alone can be misleading — a test at 85% could be flaky (failing sporadically everywhere) or broken in one specific lane (failing deterministically there, passing everywhere else). Use these techniques to distinguish the two.
+
+### Failure dispersion across lanes
+
+Count how many lanes show failures for a given test:
+
+- **Concentrated failures** (1–2 lanes account for most failures): likely a lane-specific or k8s-version-specific issue, not a true flake. Check whether those lanes share an environment trait (same k8s version, same provider, Serial tag).
+- **Dispersed failures** (failures spread across many lanes): genuine flaky behavior — the test is nondeterministic regardless of environment.
+
+When failures are concentrated, upgrade the severity toward "likely-pr-related" or "lane-specific issue" even if the aggregate success rate is low. When dispersed, treat it as a stronger flake signal even if the aggregate rate looks moderate.
+
+### Periodic lanes as ground truth
+
+**Periodic lanes** (prefixed `periodic-`) run against `main` and reflect the true baseline flakiness of a test. **Presubmit lanes** (prefixed `pull-`) run against PR code and may fail due to faulty changes.
+
+- Base the flakiness assessment primarily on **periodic lane** success rates
+- If a test fails frequently in periodic lanes, it is a known flake regardless of presubmit results
+- If a test passes consistently in periodic lanes but fails in the presubmit lane under analysis, the failure is likely PR-related
+- Presubmit lane data is supplementary — mention it but don't let it override the periodic signal
+
+### Infrastructure flake detection
+
+When multiple unrelated tests all fail in the **same lane(s)** during the analysis period, suspect an infrastructure problem rather than individual test flakiness:
+
+- Look for lanes where many of the build's failed tests show low success rates simultaneously
+- If a lane shows failures across tests that share no code path, that lane likely experienced infra instability (node issues, storage problems, network flakes)
+- Flag these as "infra flake" and note the affected lane — the individual tests are not at fault
+
+### Windowed trend analysis
+
+Use `--days` to compare different time windows and detect trends:
+
+- **7 days vs 21 days**: if the 7-day rate is much worse than the 21-day rate, the flakiness is recent (possible regression). If similar, it's a long-standing flake.
+- **Recommend quarantine** when a test shows sustained flakiness (consistent across windows) with dispersed failures
+
+## Presenting results
+
+### What to report
+
+For each failed test, report:
+1. The test name
+2. The overall success rate and total runs (succeeded + failed)
+3. The severity classification
+4. The **failure pattern** — concentrated in specific lanes/versions or dispersed across many (this often matters more than the raw success rate)
+5. If severity is "unknown", note that the test may be new or not covered by flakefinder
+6. Per-k8s-version success rates, highlighting versions where the test is notably worse
+7. Per-lane details, **leading with periodic lanes** — call out when a specific periodic lane drives the flakiness
+8. Note when periodic and presubmit lanes diverge (e.g. periodic passes 100% but pull lane shows failures)
+9. When multiple tests share the same failing lane pattern, group them and flag as a probable infrastructure flake
+
+### Summary table
+
+After the per-test details, provide a summary table:
+
+| Test | Success Rate | Runs | Pattern | Assessment |
+|------|-------------|------|---------|------------|
+
+Where **Pattern** is one of:
+- **dispersed** — failures spread across many lanes (true flake)
+- **concentrated** — failures in 1–2 lanes (lane-specific or version-specific)
+- **infra-correlated** — fails alongside other unrelated tests in same lane(s)
+- **unknown** — not found in flakefinder
+
+And **Assessment** refines the raw severity by incorporating the pattern analysis.
+
+## Suggested follow-up skills
+
+After the failure rate summary, suggest follow-up analyses when appropriate:
+- **change-relevance**: for failures classified as "likely-pr-related" — confirms whether the PR actually changed files in the test's code area before blaming the PR
+- **lane-failure-rate**: for failures concentrated in specific lanes — shows whether those lanes are generally unhealthy or if the concentration is specific to this test
+- **analyze-build**: for infra-correlated failures or when the k8s analysis would help — deep-dives into cluster state (pods, nodes, events, etcd) to find infrastructure root causes

--- a/.gemini/skills/trigger-pr-jobs/SKILL.md
+++ b/.gemini/skills/trigger-pr-jobs/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: trigger-pr-jobs
+description: Identify and retrigger missing or failed required Prow status checks for a GitHub pull request.
+argument-hint: <pr-url>
+allowed-tools: Bash(gh api *), Bash(gh pr checks *), Bash(gh pr comment *), Bash(gh pr view *)
+---
+
+## Overview
+
+This skill identifies required status checks that are either missing (no result) or failed on a GitHub pull request, then posts `/test` commands to retrigger them.
+
+It works for any repo in the `kubevirt` GitHub org that uses Prow.
+
+## Steps
+
+### 1. Extract PR details
+
+Parse the PR URL from $ARGUMENTS to get `owner`, `repo`, and `pr_number`. Validate that all three values were successfully extracted and are non-empty. If the URL is malformed or any component is missing, report the error to the user and stop.
+
+### 2. Get the target branch
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number} --jq '.base.ref'
+```
+
+### 3. Get required status checks
+
+```bash
+gh api repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks --jq '.contexts[]'
+```
+
+If this returns a 404 (branch protection not configured), treat it as having no required checks. Tell the user that no required status checks are configured for the target branch and stop.
+
+### 4. Get current check results
+
+Get the status of all checks reported on the PR:
+
+```bash
+gh pr checks {pr_number} --repo {owner}/{repo} --json name,state,bucket
+```
+
+This returns a JSON array of objects containing the check name and its current state (e.g., `SUCCESS`, `FAILURE`, `PENDING`).
+
+### 5. Find checks to trigger
+
+Compare the required checks against the checks present on the commit. A check needs triggering if it is:
+- **Missing**: appears in required checks but has no status/check-run at all on the latest commit
+- **Failed**: appears in the PR checks with `fail` status
+
+**Only trigger Prow jobs.** Filter to job names starting with `pull-`. Non-Prow checks cannot be triggered via `/test` and must be excluded:
+- `dco`, `tide` — Prow tide/plugin statuses, not jobs
+- `coverage/coveralls` — third-party service
+- GitHub Actions checks (e.g. `check-vep`) — triggered by GitHub, not Prow
+- Other third-party checks (e.g. `Sourcery review`)
+
+If there are no checks to trigger, tell the user and stop.
+
+### 6. Post /test commands
+
+Post a **single comment** on the PR with one `/test {job_name}` line per check that needs triggering:
+
+```bash
+gh pr comment {pr_number} --repo {owner}/{repo} --body "/test job-1
+/test job-2
+/test job-3"
+```
+
+Always combine all `/test` lines into one comment to avoid noise on the PR.
+
+## Smart retrigger guidance
+
+Before posting `/test` commands, consider whether retriggering is likely to help:
+
+- **Known flakes** (test has < 80% success rate in flakefinder): retriggering will likely succeed — worth doing
+- **Likely PR-related** (test has > 95% success rate): retriggering will likely fail again — suggest the user investigate with `analyze-build` or `test-failure-rate` first instead of wasting CI resources
+- **Infra failures** (many unrelated tests failed together): retriggering may help if the infra event was transient
+
+When there are many failures, suggest running `test-failure-rate` on one of the failed build URLs first to quickly assess whether the failures are flaky. If all failures are known flakes, retrigger confidently. If most are likely PR-related, warn the user before retriggering.
+
+## Output
+
+Present a summary table to the user showing:
+- Which checks were missing (no result)
+- Which checks were failed
+- Confirmation that the `/test` commands were posted, with a link to the comment


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adapts skills to be usable by Gemini CLI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
