### PR TITLE
fix: retry on transient 502/503 in Prow HTTP client

### DIFF
--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -65,7 +65,7 @@ func finishedJSONURL(baseURL string, org string, repo string, prNumber string, j
 func checkSIGCIFailure(job job) bool {
 	if job.failure {
 		junitURL := fmt.Sprintf("%s/junit.functest.xml", job.artifactsURL)
-		resp, err := http.Get(junitURL)
+		resp, err := HttpGetWithRetry(junitURL)
 		if err != nil {
 			return true
 		}
@@ -138,7 +138,7 @@ func getLatestCommit(node *html.Node) (latestCommit string) {
 
 func filterForLastCommit(storageBaseURL string, org string, repo string, prNumber string, latestCommit string, jobList []job, notBefore time.Time) (filteredJobList []job, err error) {
 	for _, job := range jobList {
-		finishedJSON, err := http.Get(finishedJSONURL(storageBaseURL, org, repo, prNumber, job.jobName, job.buildNumber))
+		finishedJSON, err := HttpGetWithRetry(finishedJSONURL(storageBaseURL, org, repo, prNumber, job.jobName, job.buildNumber))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get %s finished.json : %s", job.jobName, err)
 		}
@@ -190,7 +190,7 @@ const (
 func filterOptionalJobs(org, repo, prNumber string, unfilteredJobs []job) ([]job, error) {
 	var filteredJobs []job
 	for _, j := range unfilteredJobs {
-		prowJobJSON, err := http.Get(fmt.Sprintf(prowJobJSONURL, org, repo, prNumber, j.jobName, j.buildNumber))
+		prowJobJSON, err := HttpGetWithRetry(fmt.Sprintf(prowJobJSONURL, org, repo, prNumber, j.jobName, j.buildNumber))
 		if err != nil {
 			return nil, err
 		}
@@ -285,14 +285,20 @@ func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response,
 			case resp.StatusCode == http.StatusNotFound:
 				httpRetryLog.Debugf("not found")
 				return nil
-			case resp.StatusCode == http.StatusGatewayTimeout:
-				httpRetryLog.Infof("failed with %d, will retry", resp.StatusCode)
-				return fmt.Errorf("failed with %d: %v", resp.StatusCode, err)
+			case resp.StatusCode == http.StatusBadGateway,
+				resp.StatusCode == http.StatusServiceUnavailable,
+				resp.StatusCode == http.StatusGatewayTimeout:
+				httpRetryLog.Warnf("transient HTTP %d, will retry", resp.StatusCode)
+				return fmt.Errorf("transient HTTP %d", resp.StatusCode)
 			default:
 				httpRetryLog.Warnf("failed with status %d, aborting", resp.StatusCode)
 				return retry.Unrecoverable(fmt.Errorf("failed to http get %s (status %d): %v", url, resp.StatusCode, err))
 			}
 		},
+		retry.Attempts(5),
+		retry.Delay(2*time.Second),
+		retry.MaxDelay(30*time.Second),
+		retry.LastErrorOnly(true),
 	)
 	return
 }

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -102,6 +102,63 @@ var _ = Describe("main", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("status 403"))
 		})
+
+		It("retries on 502 Bad Gateway and succeeds", func() {
+			attempt := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt++
+				if attempt < 3 {
+					w.WriteHeader(http.StatusBadGateway)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			resp, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(attempt).To(Equal(3))
+		})
+
+		It("retries on 503 Service Unavailable and succeeds", func() {
+			attempt := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt++
+				if attempt < 2 {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			resp, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(attempt).To(Equal(2))
+		})
+
+		It("retries on 504 Gateway Timeout and succeeds", func() {
+			attempt := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt++
+				if attempt < 2 {
+					w.WriteHeader(http.StatusGatewayTimeout)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			resp, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(attempt).To(Equal(2))
+		})
+
+		It("returns error after exhausting retries on persistent 502", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+			}))
+			_, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("transient HTTP 502"))
+		})
 	})
 
 	Context("filterForLastCommit time filtering", func() {

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/html"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -103,53 +104,26 @@ var _ = Describe("main", func() {
 			Expect(err.Error()).To(ContainSubstring("status 403"))
 		})
 
-		It("retries on 502 Bad Gateway and succeeds", func() {
-			attempt := 0
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				attempt++
-				if attempt < 3 {
-					w.WriteHeader(http.StatusBadGateway)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-			}))
-			resp, err := DoHTTPWithRetry(server.URL, http.Get)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
-			Expect(attempt).To(Equal(3))
-		})
-
-		It("retries on 503 Service Unavailable and succeeds", func() {
-			attempt := 0
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				attempt++
-				if attempt < 2 {
-					w.WriteHeader(http.StatusServiceUnavailable)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-			}))
-			resp, err := DoHTTPWithRetry(server.URL, http.Get)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
-			Expect(attempt).To(Equal(2))
-		})
-
-		It("retries on 504 Gateway Timeout and succeeds", func() {
-			attempt := 0
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				attempt++
-				if attempt < 2 {
-					w.WriteHeader(http.StatusGatewayTimeout)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-			}))
-			resp, err := DoHTTPWithRetry(server.URL, http.Get)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
-			Expect(attempt).To(Equal(2))
-		})
+		DescribeTable("retries on transient 5xx and succeeds",
+			func(statusCode int, failCount int) {
+				attempt := 0
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					attempt++
+					if attempt <= failCount {
+						w.WriteHeader(statusCode)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+				}))
+				resp, err := DoHTTPWithRetry(server.URL, http.Get)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(attempt).To(Equal(failCount + 1))
+			},
+			Entry("502 Bad Gateway", http.StatusBadGateway, 2),
+			Entry("503 Service Unavailable", http.StatusServiceUnavailable, 1),
+			Entry("504 Gateway Timeout", http.StatusGatewayTimeout, 1),
+		)
 
 		It("returns error after exhausting retries on persistent 502", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- `DoHTTPWithRetry` only retried on HTTP 504; a 502 Bad Gateway from `prow.ci.kubevirt.io` was treated as unrecoverable and aborted the entire `badges-update` job ([failed run](https://github.com/kubevirt/ci-health/actions/runs/28436754194/job/84264436248))
- Expand retry to cover 502, 503, and 504, matching the existing GitHub GraphQL client (`pkg/gh/main.go`)
- Add explicit backoff parameters (5 attempts, 2s delay, 30s max) instead of relying on `retry-go` defaults
- Replace 3 bare `http.Get` calls in the same package with `HttpGetWithRetry`

## Test plan

- [x] All 14 existing + 4 new tests pass (`go test ./pkg/sigretests/...`)
- [x] `golangci-lint run ./pkg/sigretests/...` clean
- [ ] Observe next scheduled `badges-update` run completes without 502-related failures

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading CI job artifacts and metadata by retrying temporary HTTP failures instead of failing immediately.
  * Refines handling of transient 5xx server errors during job checks and metadata lookups to reduce false negatives from intermittent outages.
  * Maintains existing behavior for missing or forbidden responses while making retry outcomes more predictable.
* **Tests**
  * Added table-driven coverage for retry behavior across transient 502/503/504 responses, including eventual success and consistent failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->