### PR TITLE
fix: use GCS API directly and retry on HTTP 500

### DIFF
--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -48,7 +48,7 @@ type SigRetests struct {
 
 var prowjobs []job
 
-const defaultStorageBaseURL = "https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow"
+const defaultStorageBaseURL = "https://storage.googleapis.com/kubevirt-prow"
 
 func prHistoryURL(org string, repo string, prNumber string) string {
 	return fmt.Sprintf("https://prow.ci.kubevirt.io/pr-history/?org=%s&repo=%s&pr=%s", org, repo, prNumber)
@@ -89,7 +89,7 @@ func filterJobs(node *html.Node) (jobs []job) {
 						e2eJob.jobName = buildLogURL[len(buildLogURL)-2]
 						e2eJob.buildNumber = buildLogURL[len(buildLogURL)-1]
 						prNumber := buildLogURL[len(buildLogURL)-3]
-						e2eJob.artifactsURL = fmt.Sprintf("https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/%s/%s/%s/artifacts",
+						e2eJob.artifactsURL = fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/%s/%s/%s/artifacts",
 							prNumber, e2eJob.jobName, e2eJob.buildNumber)
 						prowjobs = append(prowjobs, e2eJob)
 						continue
@@ -285,7 +285,8 @@ func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response,
 			case resp.StatusCode == http.StatusNotFound:
 				httpRetryLog.Debugf("not found")
 				return nil
-			case resp.StatusCode == http.StatusBadGateway,
+			case resp.StatusCode == http.StatusInternalServerError,
+				resp.StatusCode == http.StatusBadGateway,
 				resp.StatusCode == http.StatusServiceUnavailable,
 				resp.StatusCode == http.StatusGatewayTimeout:
 				httpRetryLog.Warnf("transient HTTP %d, will retry", resp.StatusCode)

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -120,10 +120,23 @@ var _ = Describe("main", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(attempt).To(Equal(failCount + 1))
 			},
+			Entry("500 Internal Server Error", http.StatusInternalServerError, 1),
 			Entry("502 Bad Gateway", http.StatusBadGateway, 2),
 			Entry("503 Service Unavailable", http.StatusServiceUnavailable, 1),
 			Entry("504 Gateway Timeout", http.StatusGatewayTimeout, 1),
 		)
+
+		It("does not retry on 501 Not Implemented", func() {
+			attempt := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt++
+				w.WriteHeader(http.StatusNotImplemented)
+			}))
+			_, err := DoHTTPWithRetry(server.URL, http.Get)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("status 501"))
+			Expect(attempt).To(Equal(1))
+		})
 
 		It("returns error after exhausting retries on persistent 502", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Replace `gcsweb.ci.kubevirt.io` proxy URLs with direct `storage.googleapis.com` access for artifact fetches — the gcsweb proxy was returning transient 500 errors that aborted the `badges-update` job ([failed run](https://github.com/kubevirt/ci-health/actions/runs/28518806159/job/84537269674#step:4:2656))
- Add HTTP 500 (Internal Server Error) to the retryable status codes alongside 502/503/504
- Add test entries for 500 retry-and-succeed and 501 not-retried

## Test plan

- [x] All 17 tests pass (`go test ./pkg/sigretests/...`)
- [x] `golangci-lint run ./pkg/sigretests/...` clean
- [ ] Observe next scheduled `badges-update` run completes without 500-related failures

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact links for failing e2e jobs now point to the updated cloud storage location, improving access to build outputs.
  * HTTP requests now retry on 500 errors in addition to other transient server failures, making temporary outages less likely to break workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->