### PR TITLE
fix: handle missing latest commit in PR history page gracefully

### DIFF
--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -244,7 +244,8 @@ func getJobsForLatestCommit(storageBaseURL string, org string, repo string, prNu
 	}
 	latestCommit := getLatestCommit(prHistoryPage)
 	if latestCommit == "" {
-		return nil, fmt.Errorf("failed to get latest commit from %s", prHistory)
+		log.Warnf("no latest commit found at %s, skipping PR", prHistory)
+		return nil, nil
 	}
 	jobsAllCommits := filterJobs(prHistoryPage)
 	prowjobs = nil
@@ -396,7 +397,8 @@ func ListPRFailures(prNumber, prOrg, prRepo string) ([]string, error) {
 	}
 	latestCommit := getLatestCommit(prHistoryPage)
 	if latestCommit == "" {
-		return nil, fmt.Errorf("failed to get latest commit from %s", prHistory)
+		log.Warnf("no latest commit found at %s, skipping PR", prHistory)
+		return nil, nil
 	}
 
 	allJobs := parseAllJobs(prHistoryPage, prOrg, prRepo)

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -24,7 +24,7 @@ func TestSIGRetests(t *testing.T) {
 }
 
 var _ = Describe("main", func() {
-	Context("parse html", func() {
+	Context("PR history page with commit link", func() {
 
 		var rootHtmlNode *html.Node
 		var prNumber string
@@ -65,6 +65,22 @@ var _ = Describe("main", func() {
 			Expect(err).To(Succeed())
 			_, err = filterOptionalJobs(org, repo, prNumber, jobsLatestCommit)
 			Expect(err).To(Succeed())
+		})
+	})
+
+	Context("PR history page without commit link", func() {
+
+		var rootHtmlNode *html.Node
+
+		BeforeEach(func() {
+			content, err := os.ReadFile("testdata/pr-history-no-commits.html")
+			Expect(err).To(Succeed())
+			rootHtmlNode, err = html.Parse(bytes.NewReader(content))
+			Expect(err).To(Succeed())
+		})
+
+		It("getLatestCommit returns empty string", func() {
+			Expect(getLatestCommit(rootHtmlNode)).To(BeEmpty())
 		})
 	})
 

--- a/pkg/sigretests/testdata/pr-history-no-commits.html
+++ b/pkg/sigretests/testdata/pr-history-no-commits.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>PR History</title>
+</head>
+<body>
+  <h1>PR Job History</h1>
+  <p>No jobs have been run for this pull request.</p>
+</body>
+</html>


### PR DESCRIPTION
## Context
The `badge-update` GitHub Action was failing with exit code 1 when processing PRs that have no Prow CI history.
Failing run: https://github.com/kubevirt/ci-health/actions/runs/28602777877/job/84815073451#step:4:1058

## What

When a PR has no Prow CI history the history page contains no commit link.
`getJobsForLatestCommit` and `ListPRFailures` both returned a fatal error in
this case, which caused the `badge-update` GitHub Action to exit 1.

## How

Changed both call sites: when `getLatestCommit` returns `""`, log a warning
and return `nil, nil` (treat the PR as having no jobs) instead of propagating
an error that aborts the run.

Added a minimal HTML fixture (`pr-history-no-commits.html`) and a unit test
that verifies `getLatestCommit` returns `""` for a page with no commit links.

Jira-ticket: https://redhat.atlassian.net/browse/CNV-XXXX

🤖 Assisted by Claude