### PR TITLE
feat(ci-failures): persist finished.json result in build analysis

### DIFF
--- a/.claude/skills/analyze-build/SKILL.md
+++ b/.claude/skills/analyze-build/SKILL.md
@@ -58,7 +58,11 @@ After data generation:
 1. Extract the session directory path from the tool's log output, then list all `*.yaml` files in that directory
 2. Read the build log analysis YAML (`{job-name}.yaml`). The structure is:
    - `job_name`: the Prow job name
-   - `build_errors`: list of build errors with `category`, `category_reason`, and `build_log_error_snippets`
+   - `build_errors`: list of build errors with `result`, `passed`, `category`, `category_reason`, and `build_log_error_snippets`
+   - `result`: the Prow build result from `finished.json` — one of `SUCCESS`, `FAILURE`, `ABORTED`, `ERROR`
+   - `passed`: boolean from `finished.json`
+   - If `category` is `prow-aborted`, the job was killed by Prow (e.g., superseded by a newer commit) — report this immediately and skip all further analysis (k8s, container logs, etc.)
+   - If `category` is `prow-error`, the job failed to schedule — report this and skip further analysis
 3. Read the k8s analysis YAML (`k8s-analysis-*.yaml`) if present. The structure is:
    - `snapshots`: list of cluster state capture points (process + failure count)
    - `findings`: list of detected issues, each with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`

--- a/.claude/skills/analyze-ci-failures/SKILL.md
+++ b/.claude/skills/analyze-ci-failures/SKILL.md
@@ -67,6 +67,11 @@ Each file contains structured data — most metadata can be read directly withou
     - `job_url`: direct link to the Prow job UI
     - `build_id`: the Prow build number (also usable to find the full build log)
     - `started` / `finished`: timestamps
+    - `result`: the Prow build result from `finished.json` — one of `SUCCESS`, `FAILURE`, `ABORTED`, `ERROR`
+    - `passed`: boolean from `finished.json`
+    - `category`: error category — one of `external`, `internal`, `pr-build`, `needs-investigation`, `prow-aborted`, `prow-error`
+    - `category_reason`: explanation of the categorization
+    - Builds with `category: prow-aborted` were killed by Prow (e.g., superseded by a newer commit) — exclude these from failure counts and cross-PR analysis. Builds with `category: prow-error` failed to schedule — also exclude.
     - `build_log_error_snippets`: list of extracted error matches, each with:
         - `error_text`: the matched error line
         - `context`: surrounding lines (typically 3 before and after) — this is the primary source for root cause analysis

--- a/.claude/skills/analyze-pr-builds/SKILL.md
+++ b/.claude/skills/analyze-pr-builds/SKILL.md
@@ -43,7 +43,9 @@ After running both commands:
      - `job_name`: the Prow job name
      - `job_url`: link to the Prow job UI
      - `build_id`: the build number
-     - `category`: error category (external, internal, pr-build, needs-investigation)
+     - `result`: the Prow build result from `finished.json` — one of `SUCCESS`, `FAILURE`, `ABORTED`, `ERROR`
+     - `passed`: boolean from `finished.json`
+     - `category`: error category (external, internal, pr-build, needs-investigation, prow-aborted, prow-error)
      - `category_reason`: explanation of the categorization
      - `error_snippets`: list of `{error_text, link}` — one-line error text and link to the log line
    - `k8s_analyses`: list of k8s analysis results per build, each with:
@@ -53,6 +55,13 @@ After running both commands:
 2. **Cross-reference failing VMI/VM names against container logs**: extract VMI/VM names from error snippets and k8s findings, then use `grep` on the cached virt-controller and virt-handler logs to find the actual rejection reason. Example: `grep -i "testvmi-xxxxx" <cached_path>`
 3. Correlate findings across all sources — e.g. CrashLoopBackOff on a component pod often explains test timeouts; etcd tmpfs exhaustion can explain apiserver failures; virt-controller log errors (schema validation, sync failures) reveal why VMIs are stuck in non-Running phases
 4. Group failures with the same root cause together
+
+### Handling aborted and error builds
+
+Jobs with `category: prow-aborted` were killed by Prow before completing (e.g., superseded by a newer commit). Jobs with `category: prow-error` failed to schedule. In both cases:
+- Report them separately as "aborted" or "scheduling error" — not as test failures
+- **Exclude them from cross-job failure correlation** below — they inflate failure counts without providing test-level signal
+- Suggest retriggering if the latest commit has no run for that job
 
 ## Cross-job failure correlation
 

--- a/.gemini/skills/analyze-build/SKILL.md
+++ b/.gemini/skills/analyze-build/SKILL.md
@@ -57,7 +57,11 @@ After data generation:
 1. Extract the session directory path from the tool's log output, then list all `*.yaml` files in that directory
 2. Read the build log analysis YAML (`{job-name}.yaml`). The structure is:
    - `job_name`: the Prow job name
-   - `build_errors`: list of build errors with `category`, `category_reason`, and `build_log_error_snippets`
+   - `build_errors`: list of build errors with `result`, `passed`, `category`, `category_reason`, and `build_log_error_snippets`
+   - `result`: the Prow build result from `finished.json` — one of `SUCCESS`, `FAILURE`, `ABORTED`, `ERROR`
+   - `passed`: boolean from `finished.json`
+   - If `category` is `prow-aborted`, the job was killed by Prow (e.g., superseded by a newer commit) — report this immediately and skip all further analysis (k8s, container logs, etc.)
+   - If `category` is `prow-error`, the job failed to schedule — report this and skip further analysis
 3. Read the k8s analysis YAML (`k8s-analysis-*.yaml`) if present. The structure is:
    - `snapshots`: list of cluster state capture points (process + failure count)
    - `findings`: list of detected issues, each with `detector`, `severity`, `kind`, `name`, `reason`, `message`, and `snapshot`

--- a/.gemini/skills/analyze-ci-failures/SKILL.md
+++ b/.gemini/skills/analyze-ci-failures/SKILL.md
@@ -65,6 +65,11 @@ Each file contains structured data — most metadata can be read directly withou
     - `job_url`: direct link to the Prow job UI
     - `build_id`: the Prow build number (also usable to find the full build log)
     - `started` / `finished`: timestamps
+    - `result`: the Prow build result from `finished.json` — one of `SUCCESS`, `FAILURE`, `ABORTED`, `ERROR`
+    - `passed`: boolean from `finished.json`
+    - `category`: error category — one of `external`, `internal`, `pr-build`, `needs-investigation`, `prow-aborted`, `prow-error`
+    - `category_reason`: explanation of the categorization
+    - Builds with `category: prow-aborted` were killed by Prow (e.g., superseded by a newer commit) — exclude these from failure counts and cross-PR analysis. Builds with `category: prow-error` failed to schedule — also exclude.
     - `build_log_error_snippets`: list of extracted error matches, each with:
         - `error_text`: the matched error line
         - `context`: surrounding lines (typically 3 before and after) — this is the primary source for root cause analysis

--- a/.gemini/skills/analyze-pr-builds/SKILL.md
+++ b/.gemini/skills/analyze-pr-builds/SKILL.md
@@ -42,7 +42,9 @@ After running both commands:
      - `job_name`: the Prow job name
      - `job_url`: link to the Prow job UI
      - `build_id`: the build number
-     - `category`: error category (external, internal, pr-build, needs-investigation)
+     - `result`: the Prow build result from `finished.json` — one of `SUCCESS`, `FAILURE`, `ABORTED`, `ERROR`
+     - `passed`: boolean from `finished.json`
+     - `category`: error category (external, internal, pr-build, needs-investigation, prow-aborted, prow-error)
      - `category_reason`: explanation of the categorization
      - `error_snippets`: list of `{error_text, link}` — one-line error text and link to the log line
    - `k8s_analyses`: list of k8s analysis results per build, each with:
@@ -52,6 +54,13 @@ After running both commands:
 2. **Cross-reference failing VMI/VM names against container logs**: extract VMI/VM names from error snippets and k8s findings, then use `grep` on the cached virt-controller and virt-handler logs to find the actual rejection reason. Example: `grep -i "testvmi-xxxxx" <cached_path>`
 3. Correlate findings across all sources — e.g. CrashLoopBackOff on a component pod often explains test timeouts; etcd tmpfs exhaustion can explain apiserver failures; virt-controller log errors (schema validation, sync failures) reveal why VMIs are stuck in non-Running phases
 4. Group failures with the same root cause together
+
+### Handling aborted and error builds
+
+Jobs with `category: prow-aborted` were killed by Prow before completing (e.g., superseded by a newer commit). Jobs with `category: prow-error` failed to schedule. In both cases:
+- Report them separately as "aborted" or "scheduling error" — not as test failures
+- **Exclude them from cross-job failure correlation** below — they inflate failure counts without providing test-level signal
+- Suggest retriggering if the latest commit has no run for that job
 
 ## Cross-job failure correlation
 

--- a/pkg/ci-failures/analyze.go
+++ b/pkg/ci-failures/analyze.go
@@ -54,6 +54,8 @@ func AnalyzeBuild(prowJobURL string) (*JobBuildErrors, error) {
 		BuildID:  buildId,
 		Started:  log.Started,
 		Finished: log.Finished,
+		Result:   log.Result,
+		Passed:   log.Passed,
 	}
 
 	lines := strings.Split(log.LogContent, "\n")

--- a/pkg/ci-failures/categorize.go
+++ b/pkg/ci-failures/categorize.go
@@ -21,6 +21,14 @@ const (
 	// CategoryNeedsInvestigation represents errors that don't match any known pattern.
 	// These require manual review to create a new pattern.
 	CategoryNeedsInvestigation ErrorCategory = "needs-investigation"
+
+	// CategoryProwAborted represents jobs that were aborted by Prow before completing.
+	// Typically caused by a newer commit push superseding the build.
+	CategoryProwAborted ErrorCategory = "prow-aborted"
+
+	// CategoryProwError represents jobs that could not be scheduled or started.
+	// These are Prow infrastructure errors, not test failures.
+	CategoryProwError ErrorCategory = "prow-error"
 )
 
 // CategorizationResult holds the category and the reason it was assigned.
@@ -148,6 +156,13 @@ func CategorizeJobBuildError(err *JobBuildError) ErrorCategory {
 }
 
 func categorizeJobBuildError(err *JobBuildError) CategorizationResult {
+	switch err.Result {
+	case "ABORTED":
+		return CategorizationResult{CategoryProwAborted, "job was aborted (finished.json result=ABORTED)"}
+	case "ERROR":
+		return CategorizationResult{CategoryProwError, "job scheduling error (finished.json result=ERROR)"}
+	}
+
 	if len(err.BuildLogErrorSnippets) == 0 {
 		return CategorizationResult{CategoryNeedsInvestigation, "no error snippets"}
 	}

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -104,6 +104,8 @@ type buildLog struct {
 	LogContent  string    `yaml:"log_content"`
 	Started     time.Time `yaml:"started"`
 	Finished    time.Time `yaml:"finished"`
+	Result      string    `yaml:"result"`
+	Passed      bool      `yaml:"passed"`
 }
 
 // DownloadBuildLogs downloads the log files for urls of failed jobs located in output/tmp/ci-failure-jobs.txt
@@ -205,6 +207,8 @@ func ExtractErrors(ciFailureJobURLs []string, outputDir string) ([]string, error
 				BuildID:  buildId,
 				Started:  log.Started,
 				Finished: log.Finished,
+				Result:   log.Result,
+				Passed:   log.Passed,
 			}
 			jobErrorsForJob.BuildErrors = append(jobErrorsForJob.BuildErrors, nextBuildError)
 
@@ -337,7 +341,7 @@ func storeBuildLogIfNotExists(url string) (string, error) {
 			return "", fmt.Errorf("failed to read build log content body: %v", err)
 		}
 
-		var finished prow.Started
+		var finished prow.Finished
 		err = json.Unmarshal(gcsFinishedFileContent, &finished)
 		if err != nil {
 			return "", fmt.Errorf("failed to decode finished: %v", err)
@@ -356,6 +360,8 @@ func storeBuildLogIfNotExists(url string) (string, error) {
 			LogContent:  string(gcsBuildLogFileContent),
 			Started:     started.Time(),
 			Finished:    finished.Time(),
+			Result:      finished.Result,
+			Passed:      finished.Passed,
 		}
 		err = encoder.Encode(&l)
 		if err != nil {

--- a/pkg/ci-failures/summarize.go
+++ b/pkg/ci-failures/summarize.go
@@ -18,6 +18,8 @@ type SummaryJob struct {
 	JobName        string                `yaml:"job_name"`
 	JobURL         string                `yaml:"job_url"`
 	BuildID        int                   `yaml:"build_id"`
+	Result         string                `yaml:"result"`
+	Passed         bool                  `yaml:"passed"`
 	Category       string                `yaml:"category"`
 	CategoryReason string                `yaml:"category_reason"`
 	ErrorSnippets  []SummaryErrorSnippet `yaml:"error_snippets"`
@@ -110,6 +112,8 @@ func readJobFile(path string) (SummaryJob, error) {
 		be := jbe.BuildErrors[0]
 		job.JobURL = be.JobURL
 		job.BuildID = be.BuildID
+		job.Result = be.Result
+		job.Passed = be.Passed
 		job.Category = be.Category
 		job.CategoryReason = be.CategoryReason
 

--- a/pkg/ci-failures/types.go
+++ b/pkg/ci-failures/types.go
@@ -46,6 +46,8 @@ type JobBuildError struct {
 	BuildID               int                     `yaml:"build_id"`
 	Started               time.Time               `yaml:"started"`
 	Finished              time.Time               `yaml:"finished"`
+	Result                string                  `yaml:"result"`
+	Passed                bool                    `yaml:"passed"`
 	Category              string                  `yaml:"category"`
 	CategoryReason        string                  `yaml:"category_reason"`
 	BuildLogErrorSnippets []*BuildLogErrorSnippet `yaml:"build_log_error_snippets"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Populates `result` and `passed` fields from `finished.json` on `JobBuildError`, enabling skills to immediately classify ABORTED and ERROR builds without parsing the build log.

## Context

The `analyze-build` command was returning `category: needs-investigation` with `category_reason: no error snippets` for builds that were aborted by Prow (e.g., superseded by a newer commit). The tool already fetched `finished.json` but decoded it into `prow.Started` instead of `prow.Finished`, silently discarding the `result` and `passed` fields.

## Changes

- Fix type bug: decode `finished.json` into `prow.Finished` (not `prow.Started`)
- Add `Result`/`Passed` fields to `JobBuildError` and `buildLog` cache structs
- Add `prow-aborted` and `prow-error` error categories that short-circuit before log snippet analysis
- Propagate `Result`/`Passed` in both `AnalyzeBuild` and `ExtractErrors` code paths

## Example output

Before:
```yaml
result: ""
category: needs-investigation
category_reason: no error snippets
```

After:
```yaml
result: ABORTED
passed: false
category: prow-aborted
category_reason: job was aborted (finished.json result=ABORTED)
```

**Special notes for your reviewer**:
The e2e test suite requires `GITHUB_TOKEN_PATH` and will fail in local runs — all unit tests pass.

---
🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI failure analysis now distinguishes aborted jobs and scheduling errors from normal test failures.
  * Failure summaries include whether a job passed and its final result, giving clearer status information.

* **Bug Fixes**
  * Improved failure counting and cross-build comparisons by excluding jobs that never completed.
  * Build log summaries now preserve final job outcome data more reliably.

* **Documentation**
  * Updated guidance to reflect the richer failure-analysis output and the new handling rules for non-completed jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->