### PR TITLE
fix(ci-failures): add patterns for uncategorized internal CI failures

### DIFF
--- a/pkg/ci-failures/analyze.go
+++ b/pkg/ci-failures/analyze.go
@@ -61,7 +61,7 @@ func AnalyzeBuild(prowJobURL string) (*JobBuildErrors, error) {
 	lines := strings.Split(log.LogContent, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := lines[i]
-		if rgExpression.MatchString(line) {
+		if buildLogLineMatchesExpression.MatchString(line) {
 			start := max(0, i-3)
 			end := min(len(lines)-1, i+3)
 			snippet := &BuildLogErrorSnippet{

--- a/pkg/ci-failures/categorize.go
+++ b/pkg/ci-failures/categorize.go
@@ -110,6 +110,12 @@ var rules = []categoryRule{
 	{CategoryInternal, "kind cluster creation failure", regexp.MustCompile(`ERROR: failed to create cluster: could not find a log line that matches`)},
 	// KubevirtCI VM never became reachable via SSH during cluster provisioning
 	{CategoryInternal, "VM SSH connection timeout during cluster provisioning", regexp.MustCompile(`could not establish a connection to the node after a generous timeout`)},
+	// Podman daemon failed to start inside CI container
+	{CategoryInternal, "Podman daemon startup failure", regexp.MustCompile(`Podman daemon failed to start`)},
+	// KIND cluster internal DNS resolution failure during node join
+	{CategoryInternal, "KIND cluster internal DNS resolution failure", regexp.MustCompile(`dial tcp: lookup kind-.+-control-plane on .+: (connection refused|i/o timeout)`)},
+	// Podman storage filesystem error (read-only or cross-device link)
+	{CategoryInternal, "Podman storage filesystem error", regexp.MustCompile(`/var/lib/(shared-images|containers/storage).*(read-only file system|invalid cross-device link)`)},
 
 	// Missing binary in CI container/environment
 	{CategoryInternal, "missing command in CI environment", regexp.MustCompile(`command not found`)},

--- a/pkg/ci-failures/categorize.go
+++ b/pkg/ci-failures/categorize.go
@@ -108,6 +108,8 @@ var rules = []categoryRule{
 	{CategoryInternal, "control plane startup failure", regexp.MustCompile(`error.*execution phase wait-control-plane: failed while waiting for the control plane to start`)},
 	// Kind cluster creation failure (log line pattern not found)
 	{CategoryInternal, "kind cluster creation failure", regexp.MustCompile(`ERROR: failed to create cluster: could not find a log line that matches`)},
+	// KubevirtCI VM never became reachable via SSH during cluster provisioning
+	{CategoryInternal, "VM SSH connection timeout during cluster provisioning", regexp.MustCompile(`could not establish a connection to the node after a generous timeout`)},
 
 	// Missing binary in CI container/environment
 	{CategoryInternal, "missing command in CI environment", regexp.MustCompile(`command not found`)},

--- a/pkg/ci-failures/categorize_test.go
+++ b/pkg/ci-failures/categorize_test.go
@@ -265,6 +265,18 @@ func TestCategorizeError(t *testing.T) {
 			expected:  CategoryInternal,
 		},
 
+		// === Internal: VM SSH timeout ===
+		{
+			name:      "VM SSH connection timeout",
+			errorText: `"could not establish a connection to the node after a generous timeout: ssh.sh echo VM is up failed"`,
+			expected:  CategoryInternal,
+		},
+		{
+			name:      "make cluster-up Error 1 with timestamp",
+			errorText: `08:30:15: make: *** [Makefile:174: cluster-up] Error 1`,
+			expected:  CategoryInternal,
+		},
+
 		// === Needs investigation ===
 		{
 			name:      "unknown error",

--- a/pkg/ci-failures/categorize_test.go
+++ b/pkg/ci-failures/categorize_test.go
@@ -277,6 +277,37 @@ func TestCategorizeError(t *testing.T) {
 			expected:  CategoryInternal,
 		},
 
+		// === Internal: Podman daemon startup failure ===
+		{
+			name:      "Podman daemon failed to start",
+			errorText: `Podman daemon failed to start successfully`,
+			expected:  CategoryInternal,
+		},
+
+		// === Internal: KIND DNS resolution failure ===
+		{
+			name:      "KIND DNS connection refused",
+			errorText: `07:08:41: dial tcp: lookup kind-1.34-control-plane on 10.89.0.1:53: read udp 10.89.0.2:38164->10.89.0.1:53: read: connection refused`,
+			expected:  CategoryInternal,
+		},
+		{
+			name:      "KIND DNS i/o timeout",
+			errorText: `07:09:12: dial tcp: lookup kind-1.34-control-plane on 10.89.0.1:53: read udp 10.89.0.2:51032->10.89.0.1:53: i/o timeout`,
+			expected:  CategoryInternal,
+		},
+
+		// === Internal: Podman storage filesystem error ===
+		{
+			name:      "Podman storage read-only filesystem",
+			errorText: `unlinkat /var/lib/shared-images/overlay/45d857b8e4ea6d442ea23c8a411b09ed0d58cd82ff905895244fdcea6659261f: read-only file system`,
+			expected:  CategoryInternal,
+		},
+		{
+			name:      "Podman storage cross-device link",
+			errorText: `rename /var/lib/shared-images/overlay/45d857b8e4ea6d442ea23c8a411b09ed0d58cd82ff905895244fdcea6659261f /var/lib/containers/storage/overlay/45d857b8e4ea: invalid cross-device link`,
+			expected:  CategoryInternal,
+		},
+
 		// === Needs investigation ===
 		{
 			name:      "unknown error",

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -26,7 +26,7 @@ const logsDir = "output/tmp/build-logs"
 var (
 	// Regex to find errors in log files
 	// make: *** [Makefile:174: cluster-sync] Error 125
-	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |^make:.*Error (1[0-9]+|[2-9][0-9]*)|command not found`)
+	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |\bmake: \*\*\*.*Error \d+|command not found|could not establish a connection to the node`)
 )
 
 // ShowCIFailureJobs fetches URLs for the CI failure runs from the data of the latest run.

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -26,7 +26,7 @@ const logsDir = "output/tmp/build-logs"
 var (
 	// Regex to find errors in log files
 	// make: *** [Makefile:174: cluster-sync] Error 125
-	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |\bmake: \*\*\*.*Error \d+|command not found|could not establish a connection to the node`)
+	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |\bmake: \*\*\*.*Error \d+|command not found|could not establish a connection to the node|Podman daemon failed to start|dial tcp: lookup kind-.+-control-plane on .+: (connection refused|i/o timeout)|/var/lib/(shared-images|containers/storage).*(read-only file system|invalid cross-device link)`)
 )
 
 // ShowCIFailureJobs fetches URLs for the CI failure runs from the data of the latest run.

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -24,9 +24,21 @@ import (
 const logsDir = "output/tmp/build-logs"
 
 var (
-	// Regex to find errors in log files
-	// make: *** [Makefile:174: cluster-sync] Error 125
-	rgExpression = regexp.MustCompile(`^E\d{4} \d\d:\d\d:\d\d\.\d+|(Error|ERROR|error)s?:|(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: |\bmake: \*\*\*.*Error \d+|command not found|could not establish a connection to the node|Podman daemon failed to start|dial tcp: lookup kind-.+-control-plane on .+: (connection refused|i/o timeout)|/var/lib/(shared-images|containers/storage).*(read-only file system|invalid cross-device link)`)
+	// Each regex matches a line occurring in the build log which we want to see
+	buildLogLineMatchesOneOfExpressions = []string{
+		`^E\d{4} \d\d:\d\d:\d\d\.\d+`,
+		`(Error|ERROR|error)s?:`,
+		`(FAIL|Failure \[)\b|timed out|panic\b|\[FAILED\]|fatal: `,
+		`\bmake: \*\*\*.*Error \d+`,
+		`command not found`,
+		`could not establish a connection to the node`,
+		`Podman daemon failed to start`,
+		`dial tcp: lookup kind-.+-control-plane on .+: (connection refused|i/o timeout)`,
+		`/var/lib/(shared-images|containers/storage).*(read-only file system|invalid cross-device link)`,
+	}
+
+	// Full Regex to find error lines in log files
+	buildLogLineMatchesExpression = regexp.MustCompile(strings.Join(buildLogLineMatchesOneOfExpressions, "|"))
 )
 
 // ShowCIFailureJobs fetches URLs for the CI failure runs from the data of the latest run.
@@ -214,7 +226,7 @@ func ExtractErrors(ciFailureJobURLs []string, outputDir string) ([]string, error
 
 			for i := len(lines) - 1; i >= 0; i-- {
 				line := lines[i]
-				if rgExpression.MatchString(line) {
+				if buildLogLineMatchesExpression.MatchString(line) {
 					start := max(0, i-3)
 					end := min(len(lines)-1, i+3)
 					// to align with what prow build log shows related to line numbers, all values are translated to 1 based


### PR DESCRIPTION
## Summary

Audited a month of `needs-investigation` entries in the ci-failures summary and added extraction + categorization patterns for all actionable failures. This eliminates 6 out of 7 uncategorized entries (the 7th has a truncated log).

**Commit 1 — VM SSH timeout + make error extraction fixes:**
- Add extraction and `CategoryInternal` rule for `could not establish a connection to the node after a generous timeout` (KubevirtCI VM never boots to SSH)
- Fix `rgExpression` make error matching: replace `^make:` with `\bmake: \*\*\*` (handles timestamp-prefixed lines) and `Error (1[0-9]+|[2-9][0-9]*)` with `Error \d+` (captures `Error 1`)

**Commit 2 — Three more internal failure patterns:**
- Podman daemon startup failure (`Podman daemon failed to start`)
- KIND cluster internal DNS resolution failure (`dial tcp: lookup kind-*-control-plane ... connection refused|i/o timeout`)
- Podman storage filesystem error (`read-only file system` / `invalid cross-device link` at `/var/lib/shared-images` or `/var/lib/containers/storage`)

Each pattern is added to both the extraction regex (`rgExpression` in `main.go`) and the categorization rules (`categorize.go`) with corresponding test cases.

## Builds covered

| Build | Root cause | New pattern |
|---|---|---|
| PR #18494 sig-storage | VM SSH timeout | `could not establish a connection to the node` |
| PR #18455 sig-operator | VM SSH timeout | `could not establish a connection to the node` |
| PR #18125 sig-network | Podman daemon failure | `Podman daemon failed to start` |
| PR #18133 sig-compute-arm64 | Podman daemon failure | `Podman daemon failed to start` |
| PR #18149 kind-sev | KIND internal DNS | `dial tcp: lookup kind-.+-control-plane` |
| PR #18314 sig-compute | Podman storage error | `/var/lib/...read-only file system` |
| PR #18373 sig-network-sriov | Log truncated | Not actionable |

## Test plan

- [x] `go test ./pkg/ci-failures/ -run TestCategorize` — all 59 tests pass
- [x] `golangci-lint run ./pkg/ci-failures/` — 0 issues
- [x] `go vet ./pkg/ci-failures/` — clean

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and categorization of CI build-log failures, including VM SSH timeout issues, Podman startup/daemon problems, KIND networking/DNS join errors, and Podman storage filesystem read-only or cross-device inconsistencies.
  * Broadened recognition of additional error patterns (e.g., “command error” output, dial timeouts, and connection refusals) to produce more accurate internal CI issue labels.
* **Tests**
  * Added new scenarios to ensure the updated classification behavior is covered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->