### PR TITLE
fix: fetch PR timeline items individually to avoid GraphQL truncation

### DIFF
--- a/pkg/gh/main.go
+++ b/pkg/gh/main.go
@@ -139,6 +139,35 @@ func (c *Client) mergeQueuePRQuery(query string) (types.MergeQueuePRList, error)
 	return mergedQuery.Search.Nodes, err
 }
 
+// FetchPRTimelineItems fetches the labeled/unlabeled timeline items for a
+// single PR via the repository query. This avoids the GitHub GraphQL
+// complexity budget that silently truncates nested timeline data when many
+// PRs are returned through the search API.
+func (c *Client) FetchPRTimelineItems(number int) (*types.MergeQueuePullRequestFragment, error) {
+	parts := strings.SplitN(c.source, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid source %q, expected owner/repo", c.source)
+	}
+
+	variables := map[string]interface{}{
+		"owner":  githubv4.String(parts[0]),
+		"repo":   githubv4.String(parts[1]),
+		"number": githubv4.Int(number),
+	}
+
+	var query struct {
+		Repository struct {
+			PullRequest types.MergeQueuePullRequestFragment `graphql:"pullRequest(number: $number)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+
+	err := c.inner.Query(context.Background(), &query, variables)
+	if err != nil {
+		return nil, err
+	}
+	return &query.Repository.PullRequest, nil
+}
+
 // ChatopsMergedPRsBetween returns a slice of PRs that were merged in the time
 // frame defined by the start and end dates given as parameters with data
 // required by chatops tools.

--- a/pkg/mergequeue/main.go
+++ b/pkg/mergequeue/main.go
@@ -61,24 +61,35 @@ func (mq *Handler) LengthAt(date time.Time) (int, []types.PR, error) {
 
 // TimesToMerge returns a map with the duration each merged PR number took to
 // land in the time frame between the given start and end dates.
+//
+// Timeline items are fetched per-PR via the repository query rather than
+// nested inside the search query. GitHub's GraphQL API silently truncates
+// nested connection data when many PRs are returned through search, which
+// caused all timeline items to be empty and the metric to report zero.
 func (mq *Handler) TimesToMerge(startDate, endDate time.Time) (map[types.PR]time.Duration, error) {
-	prs, err := mq.client.MergedPRsBetween(startDate, endDate)
+	barePRs, err := mq.client.MergedPRsBetween(startDate, endDate)
 	if err != nil {
 		return nil, err
 	}
 
 	result := map[types.PR]time.Duration{}
-	for _, prItem := range prs {
-		log.Debugf("TimesToMerge: calculating mq date entered for PR num %d merged at %s", prItem.Number, prItem.MergedAt)
-		mqStart := DatePREntered(&prItem.MergeQueuePullRequestFragment, prItem.MergedAt)
+	for _, barePR := range barePRs {
+		prWithTimeline, err := mq.client.FetchPRTimelineItems(barePR.Number)
+		if err != nil {
+			log.WithError(err).Warnf("TimesToMerge: failed to fetch timeline for PR %d, skipping", barePR.Number)
+			continue
+		}
+
+		log.Debugf("TimesToMerge: calculating mq date entered for PR num %d merged at %s", barePR.Number, barePR.MergedAt)
+		mqStart := DatePREntered(prWithTimeline, barePR.MergedAt)
 		if mqStart.Equal(zeroDate) {
-			log.Debugf("TimesToMerge: Merge queue enter date not found for PR %d", prItem.Number)
+			log.Debugf("TimesToMerge: Merge queue enter date not found for PR %d", barePR.Number)
 		} else {
 			pr := types.PR{
-				Number:   prItem.Number,
-				MergedAt: prItem.MergedAt.Format(constants.DateFormat),
+				Number:   barePR.Number,
+				MergedAt: barePR.MergedAt.Format(constants.DateFormat),
 			}
-			result[pr] = prItem.MergedAt.Sub(mqStart)
+			result[pr] = barePR.MergedAt.Sub(mqStart)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- The "hours to merge" badge has been permanently stuck at `0.00 ± std 0.00` because GitHub's GraphQL API silently truncates nested `timelineItems` data when the search query returns many PRs (60+ in a 7-day window exceeds the complexity budget)
- Switches `TimesToMerge` to a two-phase fetch: first get the merged PR list via search, then fetch each PR's labeled/unlabeled timeline items individually via the `repository` query, which is not subject to the search complexity budget
- Verified against the live API: badge now correctly reports `14.64 ± std 11.28` hours (53 data points from 63 merged PRs)

## Root cause

The `mergeQueuePRQuery` function fetches PRs via `search(query: ..., type: ISSUE, first: 100)` with `timelineItems(first: 100, ...)` nested inside. When 60+ PRs are returned, the total nested node count (~6000+) exceeds GitHub's GraphQL complexity budget. GitHub silently returns empty `nodes: []` arrays for the timeline items of most PRs — no error is raised. `DatePREntered` then sees no label events, returns zero for every PR, and `Average([])` produces `0`.

Confirmed by querying the API directly:
- 3 PRs with `first:100` timeline items → all return full data ✓
- 69 PRs with `first:100` timeline items → first 45 PRs return **0 nodes** despite having 17-57 events each

The fix fetches timeline items per-PR via `repository(owner, name) { pullRequest(number) { timelineItems(...) } }`, which avoids the search nesting complexity entirely.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all unit tests, e2e skipped — requires token)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Ran focused time-to-merge test against live GitHub API — 53/63 PRs produced valid data points, badge shows `14.64 ± std 11.28` hours

🤖 Assisted by Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge queue duration calculations by retrieving pull request timeline details directly.
  * Added handling for unavailable timeline data so other pull requests can still be processed.
  * Ensured queue durations are recorded only when a valid entry timestamp is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->