### PR TITLE
ci: bring back GitHub Actions test workflow

### DIFF
--- a/.github/workflows/ci-health-tests.yaml
+++ b/.github/workflows/ci-health-tests.yaml
@@ -1,0 +1,31 @@
+name: ci-health-tests
+
+on:
+  pull_request:
+    paths:
+      - 'cmd/**'
+      - 'e2e/**'
+      - 'pkg/**'
+      - 'go.*'
+      - '.github/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: docker.io/golang:1.26-alpine
+    steps:
+      - name: Checkout Git repository
+        id: checkout
+        uses: actions/checkout@v6
+
+      - name: Run tests
+        id: test
+        run: |
+          export GITHUB_TOKEN_PATH='/run/github-token'
+
+          echo -n '${{ secrets.GITHUB_TOKEN }}' >"${GITHUB_TOKEN_PATH}"
+
+          go test ./...

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The central artifact is `output/kubevirt/kubevirt/results.json`: `badges-update.
 |----------|---------|---------|
 | `badges-update.yaml` | Scheduled every 3 hours | Runs `stats` for last 7 days, commits updated badges and `results.json` |
 | `ci-failures.yml` | Push to `main` modifying `results.json` | Runs `ci-failures generate report`, commits updated markdown summary |
+| `ci-health-tests.yml` | Pull request that modifies Go code | Runs `go test`, validates changes |
 | `historical-update.yaml` | Weekly (Monday 00:10 UTC) | Runs `batch` fetch+plot for trend metrics, commits updated plots |
 
 ### Prow Postsubmit


### PR DESCRIPTION
**What this PR does / why we need it**:

Bring back the GitHub action which was used to validate go code changes.

It seems using the token from the github action itself is sufficient to query the required data.

Therefore, there is no need to switch to the `pull_request_target` event to expose the token from the repository variables.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #130

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated health checks for pull requests that modify Go code or related project files.
  * The checks run the full Go test suite in a consistent environment.

* **Documentation**
  * Updated the GitHub Actions workflow documentation to include the new health check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->