### PR TITLE
feat(ci-failures): add log-grep-stats cmd

### DIFF
--- a/cmd/ci-failures/main.go
+++ b/cmd/ci-failures/main.go
@@ -126,14 +126,17 @@ Accepts a Prow job URL, e.g.:
 		RunE: analyzeK8s,
 	}
 
-	testRateDays           int
-	laneRateDays           int
-	laneRateMaxSuccessRate float64
-	flakeOverviewDays      int
-	flakeOverviewFilter    string
-	flakeOverviewConc      int
-	showLogTail            int
-	showLogGrep            string
+	testRateDays              int
+	laneRateDays              int
+	laneRateMaxSuccessRate    float64
+	flakeOverviewDays         int
+	flakeOverviewFilter       string
+	flakeOverviewConc         int
+	showLogTail               int
+	showLogGrep               string
+	logGrepStatsSince         string
+	logGrepStatsCaseSensitive bool
+	logGrepStatsConcurrency   int
 
 	testRateCmd = &cobra.Command{
 		Use:   "test-rate [prow-job-url]",
@@ -200,6 +203,21 @@ Use --tail to print only the last N lines (default: all).
 Use --grep to filter lines matching a pattern (case-insensitive).`,
 		Args: cobra.ExactArgs(1),
 		RunE: showLog,
+	}
+
+	logGrepStatsCmd = &cobra.Command{
+		Use:   "log-grep-stats [pattern]",
+		Short: "Show per-month statistics for a pattern in CI failure build logs.",
+		Long: `Scan git history of output/kubevirt/kubevirt/results.json to collect all
+CI failure build URLs since a given date, download their build logs, and search
+for a text pattern. Outputs per-month statistics with matching build URLs.
+
+Requires --since to specify how far back to search in git history.
+
+Example:
+  ci-failures log-grep-stats "could not establish a connection to the node after a generous timeout" --since 2025-01-01`,
+		Args: cobra.ExactArgs(1),
+		RunE: logGrepStats,
 	}
 
 	discoverLanesCmd = &cobra.Command{
@@ -576,6 +594,36 @@ func discoverLanes(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+func logGrepStats(_ *cobra.Command, args []string) error {
+	pattern := args[0]
+
+	if logGrepStatsSince == "" {
+		return fmt.Errorf("--since is required (e.g. --since 2025-01-01)")
+	}
+
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	result, err := cifailures.AnalyzeLogGrepStats(repoDir, pattern, logGrepStatsSince, !logGrepStatsCaseSensitive, logGrepStatsConcurrency)
+	if err != nil {
+		return fmt.Errorf("failed to analyze log grep stats: %w", err)
+	}
+
+	if err = os.MkdirAll(tmpOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpOutputPath, "log-grep-stats.yaml")
+	if err = cifailures.WriteLogGrepStatsResultYAML(outputPath, result); err != nil {
+		return fmt.Errorf("failed to write YAML output: %w", err)
+	}
+
+	log.Infof("wrote log grep stats to %s (%d matched out of %d CI failure URLs, %d total URLs)", outputPath, result.TotalMatched, result.CIFailureURLs, result.TotalURLs)
+	return nil
+}
+
 func summarizeSession(_ *cobra.Command, _ []string) error {
 	if tmpOutputPath == "output/tmp" {
 		return fmt.Errorf("no session ID set; use --session-id or set CLAUDE_CODE_SESSION_ID")
@@ -644,6 +692,10 @@ func init() {
 	showLogCmd.Flags().IntVar(&showLogTail, "tail", 0, "Print only the last N lines (0 = all)")
 	showLogCmd.Flags().StringVar(&showLogGrep, "grep", "", "Filter lines containing this pattern (case-insensitive)")
 
+	logGrepStatsCmd.Flags().StringVar(&logGrepStatsSince, "since", "", "How far back in git history (YYYY-MM-DD, required)")
+	logGrepStatsCmd.Flags().BoolVar(&logGrepStatsCaseSensitive, "case-sensitive", false, "Perform case-sensitive matching (default: case-insensitive)")
+	logGrepStatsCmd.Flags().IntVar(&logGrepStatsConcurrency, "concurrency", 10, "Parallel junit checks and build log downloads")
+
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(analyzeBuildCmd)
 	rootCmd.AddCommand(analyzePRCmd)
@@ -655,6 +707,7 @@ func init() {
 	rootCmd.AddCommand(summarizeSessionCmd)
 	rootCmd.AddCommand(discoverLanesCmd)
 	rootCmd.AddCommand(showLogCmd)
+	rootCmd.AddCommand(logGrepStatsCmd)
 	generateCmd.AddCommand(yamlCmd)
 	generateCmd.AddCommand(mdCmd)
 	generateCmd.AddCommand(reportCmd)

--- a/pkg/ci-failures/log_grep_stats.go
+++ b/pkg/ci-failures/log_grep_stats.go
@@ -1,0 +1,315 @@
+package cifailures
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+type LogGrepStatsResult struct {
+	Pattern         string              `yaml:"pattern"`
+	Since           string              `yaml:"since"`
+	CaseInsensitive bool                `yaml:"case_insensitive"`
+	TotalURLs       int                 `yaml:"total_urls"`
+	CIFailureURLs   int                 `yaml:"ci_failure_urls"`
+	TotalMatched    int                 `yaml:"total_matched"`
+	Months          []LogGrepMonthStats `yaml:"months"`
+}
+
+type LogGrepMonthStats struct {
+	Month   string              `yaml:"month"`
+	Matched int                 `yaml:"matched"`
+	Builds  []LogGrepBuildMatch `yaml:"builds"`
+}
+
+type LogGrepBuildMatch struct {
+	BuildID     int       `yaml:"build_id"`
+	ProwJobURL  string    `yaml:"prow_job_url"`
+	Started     time.Time `yaml:"started"`
+	Occurrences int       `yaml:"occurrences"`
+}
+
+func AnalyzeLogGrepStats(repoDir, pattern, since string, caseInsensitive bool, concurrency int) (*LogGrepStatsResult, error) {
+	if concurrency < 1 {
+		concurrency = 10
+	}
+
+	urls, err := collectFailureURLsFromGitHistory(repoDir, since)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect failure URLs from git history: %w", err)
+	}
+
+	log.Infof("collected %d unique failure URLs from git history since %s", len(urls), since)
+
+	ciFailureURLs, err := filterCIFailureURLs(urls, concurrency)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter CI failure URLs: %w", err)
+	}
+
+	log.Infof("filtered to %d CI failure URLs (no junit.functest.xml)", len(ciFailureURLs))
+
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create build logs directory: %w", err)
+	}
+
+	logPaths, err := downloadBuildLogsForURLs(ciFailureURLs, concurrency)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download build logs: %w", err)
+	}
+
+	log.Infof("downloaded/cached %d build logs", len(logPaths))
+
+	result := grepBuildLogs(logPaths, pattern, caseInsensitive)
+	result.Since = since
+	result.TotalURLs = len(urls)
+	result.CIFailureURLs = len(ciFailureURLs)
+
+	return result, nil
+}
+
+func collectFailureURLsFromGitHistory(repoDir, since string) ([]string, error) {
+	cmd := exec.Command("git", "log", "--format=%H", fmt.Sprintf("--since=%s", since), "--", "output/kubevirt/kubevirt/results.json")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log failed: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 || (len(lines) == 1 && lines[0] == "") {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, commitHash := range lines {
+		commitHash = strings.TrimSpace(commitHash)
+		if commitHash == "" {
+			continue
+		}
+
+		showCmd := exec.Command("git", "show", fmt.Sprintf("%s:output/kubevirt/kubevirt/results.json", commitHash))
+		showCmd.Dir = repoDir
+		jsonBytes, err := showCmd.Output()
+		if err != nil {
+			log.Warnf("skipping commit %s: git show failed: %v", commitHash, err)
+			continue
+		}
+
+		urls, err := extractFailureURLsFromJSON(jsonBytes)
+		if err != nil {
+			log.Warnf("skipping commit %s: failed to parse results.json: %v", commitHash, err)
+			continue
+		}
+
+		for _, u := range urls {
+			seen[normalizeJobURL(u)] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for u := range seen {
+		result = append(result, u)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func extractFailureURLsFromJSON(data []byte) ([]string, error) {
+	var result struct {
+		Data struct {
+			SIGRetests struct {
+				FailedJobLeaderBoard []struct {
+					FailureURLs []string `json:"FailureURLs"`
+				} `json:"FailedJobLeaderBoard"`
+			} `json:"SIGRetests"`
+		} `json:"Data"`
+	}
+
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	var urls []string
+	for _, board := range result.Data.SIGRetests.FailedJobLeaderBoard {
+		urls = append(urls, board.FailureURLs...)
+	}
+	return urls, nil
+}
+
+type ciFilterResult struct {
+	url  string
+	pass bool
+}
+
+func filterCIFailureURLs(urls []string, concurrency int) ([]string, error) {
+	results := make(chan ciFilterResult, len(urls))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for _, u := range urls {
+		wg.Add(1)
+		go func(url string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			exists, err := checkJunitFuncTestXMLExists(url)
+			if err != nil {
+				log.Warnf("junit check failed for %s: %v, including URL", url, err)
+				results <- ciFilterResult{url: url, pass: true}
+				return
+			}
+			results <- ciFilterResult{url: url, pass: !exists}
+		}(u)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var filtered []string
+	for r := range results {
+		if r.pass {
+			filtered = append(filtered, r.url)
+		}
+	}
+	sort.Strings(filtered)
+	return filtered, nil
+}
+
+type downloadResult struct {
+	url  string
+	path string
+	err  error
+}
+
+func downloadBuildLogsForURLs(urls []string, concurrency int) ([]string, error) {
+	results := make(chan downloadResult, len(urls))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for _, u := range urls {
+		wg.Add(1)
+		go func(url string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			path, err := storeBuildLogIfNotExists(url)
+			results <- downloadResult{url: url, path: path, err: err}
+		}(u)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var paths []string
+	for r := range results {
+		if r.err != nil {
+			log.Warnf("failed to download build log for %s: %v, skipping", r.url, r.err)
+			continue
+		}
+		paths = append(paths, r.path)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func grepBuildLogs(logPaths []string, pattern string, caseInsensitive bool) *LogGrepStatsResult {
+	searchPattern := pattern
+	if caseInsensitive {
+		searchPattern = strings.ToLower(pattern)
+	}
+
+	monthMap := make(map[string]*LogGrepMonthStats)
+
+	for _, logPath := range logPaths {
+		bl, err := readBuildLog(logPath)
+		if err != nil {
+			log.Warnf("failed to read build log %s: %v, skipping", logPath, err)
+			continue
+		}
+
+		content := bl.LogContent
+		if caseInsensitive {
+			content = strings.ToLower(content)
+		}
+
+		count := strings.Count(content, searchPattern)
+		if count == 0 {
+			continue
+		}
+
+		buildID, err := buildIDFromJobURL(bl.ProwJobURL)
+		if err != nil {
+			log.Warnf("failed to extract build ID from %s: %v, skipping", bl.ProwJobURL, err)
+			continue
+		}
+
+		monthKey := bl.Started.Format("2006-01")
+		ms, exists := monthMap[monthKey]
+		if !exists {
+			ms = &LogGrepMonthStats{Month: monthKey}
+			monthMap[monthKey] = ms
+		}
+		ms.Matched++
+		ms.Builds = append(ms.Builds, LogGrepBuildMatch{
+			BuildID:     buildID,
+			ProwJobURL:  bl.ProwJobURL,
+			Started:     bl.Started,
+			Occurrences: count,
+		})
+	}
+
+	var months []LogGrepMonthStats
+	for _, ms := range monthMap {
+		sort.Slice(ms.Builds, func(i, j int) bool {
+			return ms.Builds[i].Started.Before(ms.Builds[j].Started)
+		})
+		months = append(months, *ms)
+	}
+	sort.Slice(months, func(i, j int) bool {
+		return months[i].Month < months[j].Month
+	})
+
+	totalMatched := 0
+	for _, m := range months {
+		totalMatched += m.Matched
+	}
+
+	return &LogGrepStatsResult{
+		Pattern:         pattern,
+		CaseInsensitive: caseInsensitive,
+		TotalMatched:    totalMatched,
+		Months:          months,
+	}
+}
+
+func WriteLogGrepStatsResultYAML(outputPath string, result *LogGrepStatsResult) error {
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outputPath, err)
+	}
+	defer func() {
+		if err := outputFile.Close(); err != nil {
+			log.WithError(err).Warn("failed closing output file")
+		}
+	}()
+
+	encoder := yaml.NewEncoder(outputFile)
+	if err := encoder.Encode(result); err != nil {
+		return fmt.Errorf("failed to encode YAML: %w", err)
+	}
+	return nil
+}

--- a/pkg/ci-failures/log_grep_stats_test.go
+++ b/pkg/ci-failures/log_grep_stats_test.go
@@ -1,0 +1,234 @@
+package cifailures
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestExtractFailureURLsFromJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "multiple boards with URLs",
+			json: `{
+				"Data": {
+					"SIGRetests": {
+						"FailedJobLeaderBoard": [
+							{"FailureURLs": ["https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/111/job-a/100"]},
+							{"FailureURLs": ["https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/222/job-b/200", "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/333/job-c/300"]}
+						]
+					}
+				}
+			}`,
+			want: 3,
+		},
+		{
+			name: "empty leaderboard",
+			json: `{
+				"Data": {
+					"SIGRetests": {
+						"FailedJobLeaderBoard": []
+					}
+				}
+			}`,
+			want: 0,
+		},
+		{
+			name: "no FailedJobLeaderBoard key",
+			json: `{
+				"Data": {
+					"SIGRetests": {}
+				}
+			}`,
+			want: 0,
+		},
+		{
+			name:    "invalid JSON",
+			json:    `{not valid`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			urls, err := extractFailureURLsFromJSON([]byte(tt.json))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(urls) != tt.want {
+				t.Fatalf("expected %d URLs, got %d", tt.want, len(urls))
+			}
+		})
+	}
+}
+
+func writeBuildLogYAML(t *testing.T, dir string, bl *buildLog) string {
+	t.Helper()
+	buildID, err := buildIDFromJobURL(bl.ProwJobURL)
+	if err != nil {
+		t.Fatalf("failed to extract build ID: %v", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%d.yaml", buildID))
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close file: %v", err)
+		}
+	}()
+	if err := yaml.NewEncoder(f).Encode(bl); err != nil {
+		t.Fatalf("failed to encode YAML: %v", err)
+	}
+	return path
+}
+
+func TestGrepBuildLogs(t *testing.T) {
+	t.Run("basic match", func(t *testing.T) {
+		dir := t.TempDir()
+		p1 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/111/job-a/100",
+			LogContent: "line1\ncould not establish a connection to the node after a generous timeout\nline3",
+			Started:    time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC),
+		})
+		p2 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/222/job-b/200",
+			LogContent: "line1\nno match here\nline3",
+			Started:    time.Date(2025, 3, 20, 10, 0, 0, 0, time.UTC),
+		})
+
+		result := grepBuildLogs([]string{p1, p2}, "could not establish a connection to the node after a generous timeout", true)
+
+		if result.TotalMatched != 1 {
+			t.Fatalf("expected 1 matched, got %d", result.TotalMatched)
+		}
+		if len(result.Months) != 1 {
+			t.Fatalf("expected 1 month, got %d", len(result.Months))
+		}
+		if result.Months[0].Month != "2025-03" {
+			t.Fatalf("expected month 2025-03, got %s", result.Months[0].Month)
+		}
+		if result.Months[0].Matched != 1 {
+			t.Fatalf("expected 1 matched in month, got %d", result.Months[0].Matched)
+		}
+	})
+
+	t.Run("multiple occurrences", func(t *testing.T) {
+		dir := t.TempDir()
+		p1 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/111/job-a/100",
+			LogContent: "error here\nerror here\nerror here",
+			Started:    time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC),
+		})
+
+		result := grepBuildLogs([]string{p1}, "error here", true)
+
+		if result.TotalMatched != 1 {
+			t.Fatalf("expected 1 matched, got %d", result.TotalMatched)
+		}
+		if result.Months[0].Builds[0].Occurrences != 3 {
+			t.Fatalf("expected 3 occurrences, got %d", result.Months[0].Builds[0].Occurrences)
+		}
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		dir := t.TempDir()
+		p1 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/111/job-a/100",
+			LogContent: "Could Not Establish A Connection",
+			Started:    time.Date(2025, 2, 5, 10, 0, 0, 0, time.UTC),
+		})
+
+		insensitive := grepBuildLogs([]string{p1}, "could not establish a connection", true)
+		if insensitive.TotalMatched != 1 {
+			t.Fatalf("case-insensitive: expected 1 matched, got %d", insensitive.TotalMatched)
+		}
+
+		sensitive := grepBuildLogs([]string{p1}, "could not establish a connection", false)
+		if sensitive.TotalMatched != 0 {
+			t.Fatalf("case-sensitive: expected 0 matched, got %d", sensitive.TotalMatched)
+		}
+	})
+
+	t.Run("month grouping", func(t *testing.T) {
+		dir := t.TempDir()
+		p1 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/111/job-a/100",
+			LogContent: "target phrase",
+			Started:    time.Date(2025, 1, 10, 10, 0, 0, 0, time.UTC),
+		})
+		p2 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/222/job-b/200",
+			LogContent: "target phrase",
+			Started:    time.Date(2025, 1, 20, 10, 0, 0, 0, time.UTC),
+		})
+		p3 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/333/job-c/300",
+			LogContent: "target phrase",
+			Started:    time.Date(2025, 2, 5, 10, 0, 0, 0, time.UTC),
+		})
+
+		result := grepBuildLogs([]string{p1, p2, p3}, "target phrase", true)
+
+		if len(result.Months) != 2 {
+			t.Fatalf("expected 2 months, got %d", len(result.Months))
+		}
+		if result.Months[0].Month != "2025-01" {
+			t.Fatalf("expected first month 2025-01, got %s", result.Months[0].Month)
+		}
+		if result.Months[0].Matched != 2 {
+			t.Fatalf("expected 2 matched in Jan, got %d", result.Months[0].Matched)
+		}
+		if result.Months[1].Month != "2025-02" {
+			t.Fatalf("expected second month 2025-02, got %s", result.Months[1].Month)
+		}
+		if result.Months[1].Matched != 1 {
+			t.Fatalf("expected 1 matched in Feb, got %d", result.Months[1].Matched)
+		}
+	})
+
+	t.Run("empty log paths", func(t *testing.T) {
+		result := grepBuildLogs(nil, "anything", true)
+
+		if result.TotalMatched != 0 {
+			t.Fatalf("expected 0 matched, got %d", result.TotalMatched)
+		}
+		if len(result.Months) != 0 {
+			t.Fatalf("expected 0 months, got %d", len(result.Months))
+		}
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		dir := t.TempDir()
+		p1 := writeBuildLogYAML(t, dir, &buildLog{
+			ProwJobURL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/111/job-a/100",
+			LogContent: "some log content without the pattern",
+			Started:    time.Date(2025, 5, 1, 10, 0, 0, 0, time.UTC),
+		})
+
+		result := grepBuildLogs([]string{p1}, "nonexistent pattern xyz", true)
+
+		if result.TotalMatched != 0 {
+			t.Fatalf("expected 0 matched, got %d", result.TotalMatched)
+		}
+		if len(result.Months) != 0 {
+			t.Fatalf("expected 0 months, got %d", len(result.Months))
+		}
+	})
+}

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const logsDir = "output/tmp/build-logs"
+var logsDir = "output/tmp/build-logs"
 
 var (
 	// Each regex matches a line occurring in the build log which we want to see


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add a tool that downloads log files from failed jobs associated with ci failures (using git history from the output reports.json file) and then greps those for a search expression.

Assisted-by: Claude Opus 4.6 :robot: 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to analyze CI failure logs for pattern matches.
  * Supports date filtering, configurable case sensitivity, concurrent processing, and YAML report output.
  * Reports match statistics grouped by month and build, with warnings for unavailable logs.

* **Tests**
  * Added coverage for log parsing, repeated and case-sensitive matches, date grouping, invalid data, and no-match results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->