### PR TITLE
Fix missing lanes with zero failures in HTML failure reports

### DIFF
--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -339,8 +339,13 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 			successOnlyCounts[name]++
 		}
 	}
-	for name, count := range successOnlyCounts {
-		sortedFailedJobs = append(sortedFailedJobs, types.FailedJob{JobName: name, SuccessCount: count})
+	successOnlyNames := make([]string, 0, len(successOnlyCounts))
+	for name := range successOnlyCounts {
+		successOnlyNames = append(successOnlyNames, name)
+	}
+	slices.Sort(successOnlyNames)
+	for _, name := range successOnlyNames {
+		sortedFailedJobs = append(sortedFailedJobs, types.FailedJob{JobName: name, SuccessCount: successOnlyCounts[name]})
 	}
 
 	dataItem.FailedJobLeaderBoard = sortedFailedJobs

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -328,6 +328,21 @@ func (h *Handler) sigRetestsProcessor(results *types.Results) (*types.Results, e
 			return cmp.Compare(prowJobID(b), prowJobID(a))
 		})
 	}
+
+	failedJobSet := make(map[string]struct{}, len(sortedFailedJobs))
+	for _, job := range sortedFailedJobs {
+		failedJobSet[job.JobName] = struct{}{}
+	}
+	successOnlyCounts := make(map[string]int)
+	for _, name := range successJobNames {
+		if _, hasFailed := failedJobSet[name]; !hasFailed {
+			successOnlyCounts[name]++
+		}
+	}
+	for name, count := range successOnlyCounts {
+		sortedFailedJobs = append(sortedFailedJobs, types.FailedJob{JobName: name, SuccessCount: count})
+	}
+
 	dataItem.FailedJobLeaderBoard = sortedFailedJobs
 	results.Data[constants.SIGRetests] = dataItem
 


### PR DESCRIPTION
## Summary

- Lanes with zero failures (success-only) were missing from the per-branch breakdown in the HTML sig failure reports while still being counted in the overall totals
- The root cause is that `FailedJobLeaderBoard` was built solely from `countFailedJobs(failedJobNames)`, which only creates entries for jobs that had at least one failure
- This fix appends success-only jobs to the leader board with `FailureCount: 0` and the correct `SuccessCount`, so all active lanes appear in the per-branch section

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (excluding e2e which requires `GITHUB_TOKEN_PATH`)
- [ ] Verify the generated HTML report includes lanes that previously had zero failures (e.g. `release-1.36` for sig-operator)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SIG-retest leaderboards now include jobs that recorded successful retests even when no failures were reported.
  * Success counts are displayed for these success-only jobs, providing a more complete view of retest outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->