### PR TITLE
chore(ci-failures): extract SIGForGroup

### DIFF
--- a/pkg/ci-failures/cifailures_suite_test.go
+++ b/pkg/ci-failures/cifailures_suite_test.go
@@ -1,0 +1,13 @@
+package cifailures
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCIFailures(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ci-failures Suite")
+}

--- a/pkg/ci-failures/main.go
+++ b/pkg/ci-failures/main.go
@@ -142,25 +142,6 @@ func DownloadBuildLogs(ciFailureJobURLs []string) ([]string, error) {
 	return logFiles, nil
 }
 
-var groups = map[string]string{
-	"sig-compute":     "sig-compute|sig-operator|sev|vgpu|windows",
-	"sig-network":     "sig-network|sriov",
-	"sig-storage":     "sig-storage",
-	"sig-monitoring":  "sig-monitoring",
-	"sig-performance": "sig-performance",
-}
-
-func SIGForGroup(whatever string) string {
-	for sig, group := range groups {
-		groupMatcher := regexp.MustCompile(group)
-		if groupMatcher.MatchString(whatever) {
-			return sig
-		}
-	}
-	log.Fatalf("no sig found for %s", whatever)
-	return ""
-}
-
 // ExtractErrors fetches failures from the build logs of build urls given through the file.
 // It writes matching lines into one file per group, under the provided output directory.
 // It returns the file names of the files created.

--- a/pkg/ci-failures/sig.go
+++ b/pkg/ci-failures/sig.go
@@ -1,0 +1,26 @@
+package cifailures
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var groups = map[string]string{
+	"sig-compute":     "sig-compute|sig-operator|sev|vgpu|windows",
+	"sig-network":     "sig-network|sriov",
+	"sig-storage":     "sig-storage",
+	"sig-monitoring":  "sig-monitoring",
+	"sig-performance": "sig-performance",
+}
+
+const UnknownSIG = "(sig-unknown)"
+
+func SIGForGroup(whatever string) (sig string, err error) {
+	for sig, group := range groups {
+		groupMatcher := regexp.MustCompile(group)
+		if groupMatcher.MatchString(whatever) {
+			return sig, nil
+		}
+	}
+	return UnknownSIG, fmt.Errorf("no sig found for %s", whatever)
+}

--- a/pkg/ci-failures/sig_test.go
+++ b/pkg/ci-failures/sig_test.go
@@ -1,0 +1,39 @@
+package cifailures
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sig", func() {
+	Context("SIGForGroup", func() {
+		DescribeTable("can extract SIG",
+			func(laneName, expectedSIG string) {
+				sig, err := SIGForGroup(laneName)
+				Expect(sig).To(BeEquivalentTo(expectedSIG))
+				Expect(err).ToNot(HaveOccurred())
+			},
+			Entry("sig-compute-arm64", "pull-kubevirt-e2e-kind-1.36-sig-compute-arm64", "sig-compute"),
+			Entry("vgpu", "pull-kubevirt-e2e-kind-1.35-vgpu", "sig-compute"),
+			Entry("sev", "pull-kubevirt-e2e-kind-1.36-sev", "sig-compute"),
+			Entry("sig-operator", "pull-kubevirt-e2e-k8s-sig-operator", "sig-compute"),
+			Entry("sig-network", "pull-kubevirt-e2e-k8s-1.34-sig-network", "sig-network"),
+			Entry("sig-network", "pull-kubevirt-e2e-k8s-1.36-sig-network-smoke", "sig-network"),
+			Entry("sriov", "pull-kubevirt-e2e-kind-sriov", "sig-network"),
+			Entry("sig-storage", "pull-kubevirt-e2e-k8s-1.35-sig-storage", "sig-storage"),
+			Entry("sig-performance", "pull-kubevirt-e2e-k8s-1.36-sig-performance-kube-burner", "sig-performance"),
+			Entry("sig-monitoring", "pull-kubevirt-e2e-k8s-1.34-sig-monitoring", "sig-monitoring"),
+		)
+
+		DescribeTable("can not extract SIG",
+			func(laneName string) {
+				sig, err := SIGForGroup(laneName)
+				Expect(err).To(HaveOccurred())
+				Expect(sig).To(BeEquivalentTo(UnknownSIG))
+			},
+			Entry("lint", "pull-kubevirt-metrics-lint"),
+			Entry("prom-rules", "pull-kubevirt-prom-rules-verify"),
+		)
+	})
+})

--- a/pkg/ci-failures/types.go
+++ b/pkg/ci-failures/types.go
@@ -1,6 +1,7 @@
 package cifailures
 
 import (
+	"log"
 	"regexp"
 	"sort"
 	"time"
@@ -70,7 +71,11 @@ func (j *JobBuildErrors) K8SVersion() string {
 }
 
 func (j *JobBuildErrors) SIG() string {
-	return SIGForGroup(j.JobName)
+	sig, err := SIGForGroup(j.JobName)
+	if err != nil {
+		log.Printf("no sig: %v", err)
+	}
+	return sig
 }
 
 var branchRegex = regexp.MustCompile(`.*(-[01]\.[0-9]+)$`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Extract func SIGForGroup for general use inside ci-health.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @Whitedyl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated categorization of CI failures by Special Interest Group (SIG).
  * Added recognition for supported build and test lane patterns.

* **Bug Fixes**
  * Improved handling of unrecognized failure sources by returning an “Unknown” classification.
  * Added error reporting when a failure cannot be mapped to a SIG.

* **Tests**
  * Added coverage for recognized and unrecognized CI failure classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->