### PR TITLE
chore(gsutil): Update AGENTS.md to reflect the migration from gsutil to gcloud storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,5 +104,5 @@ The repository uses GitHub Actions and a Prow postsubmit in `kubevirt/project-in
 - **Action**:
     1. Loops over SIGs: compute, network, storage, operator, monitoring.
     2. Runs `go run ./cmd/html-report --sig <SIG> --results-path ./output/kubevirt/kubevirt/results.json` for each.
-    3. Uploads the generated HTML files to `gs://kubevirt-prow/reports/sig-failure-reports/` via `gsutil`.
+    3. Uploads the generated HTML files to `gs://kubevirt-prow/reports/sig-failure-reports/` via `gcloud storage`.
     4. The reports are then available at `https://storage.googleapis.com/kubevirt-prow/reports/sig-failure-reports/sig-<name>-failure-report.html`.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR follows the migration from gsutil to gcloud storage. This PR has no script change but only an update to AGENTS.md reflecting the migration. 

**Special notes for your reviewer**:
/cc @dollierp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI health report workflow documentation to reference the current `gcloud storage` command for uploading generated HTML reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->