### PR TITLE
Add isRetriableNetworkError() to classify transient network errors

### DIFF
--- a/pkg/sigretests/main.go
+++ b/pkg/sigretests/main.go
@@ -1,10 +1,13 @@
 package sigretests
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -17,6 +20,10 @@ import (
 
 	"github.com/avast/retry-go"
 )
+
+var httpClient = &http.Client{
+	Timeout: 90 * time.Second,
+}
 
 const org = "kubevirt"
 const repo = "kubevirt"
@@ -266,11 +273,44 @@ func getJobsForLatestCommit(storageBaseURL string, org string, repo string, prNu
 }
 
 func HttpGetWithRetry(url string) (resp *http.Response, err error) {
-	return DoHTTPWithRetry(url, http.Get)
+	return DoHTTPWithRetry(url, httpClient.Get)
 }
 
 func HttpHeadWithRetry(url string) (resp *http.Response, err error) {
-	return DoHTTPWithRetry(url, http.Head)
+	return DoHTTPWithRetry(url, httpClient.Head)
+}
+
+// isRetriableNetworkError determines if a network error should trigger a retry.
+// Returns true for timeouts, temporary DNS failures, and connection issues.
+func isRetriableNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	if os.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	retriablePatterns := []string{
+		"dial tcp",
+		"i/o timeout",
+		"connection refused",
+		"connection reset",
+		"Temporary failure in name resolution",
+		"no such host",
+		"network is unreachable",
+		"TLS handshake timeout",
+	}
+
+	for _, pattern := range retriablePatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response, err error)) (resp *http.Response, err error) {
@@ -280,7 +320,11 @@ func DoHTTPWithRetry(url string, httpVerb func(url string) (resp *http.Response,
 			resp, err = httpVerb(url)
 			switch {
 			case err != nil:
-				httpRetryLog.Warnf("failed with error %v, aborting", err)
+				if isRetriableNetworkError(err) {
+					httpRetryLog.Warnf("transient network error, will retry: %v", err)
+					return err
+				}
+				httpRetryLog.Warnf("failed with non-retriable error %v, aborting", err)
 				return retry.Unrecoverable(err)
 			case resp.StatusCode == http.StatusOK:
 				httpRetryLog.Debugf("succeeded")

--- a/pkg/sigretests/main_test.go
+++ b/pkg/sigretests/main_test.go
@@ -2,9 +2,12 @@ package sigretests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -17,6 +20,15 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
+
+// timeoutError is a test helper that satisfies the net.Error interface with Timeout() == true.
+type timeoutError struct {
+	msg string
+}
+
+func (e *timeoutError) Error() string   { return e.msg }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
 
 func TestSIGRetests(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -161,6 +173,108 @@ var _ = Describe("main", func() {
 			_, err := DoHTTPWithRetry(server.URL, http.Get)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("transient HTTP 502"))
+		})
+	})
+
+	Context("DoHTTPWithRetry network error handling", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("retries on timeout errors", func() {
+			attempt := 0
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt++
+				if attempt == 1 {
+					time.Sleep(2 * time.Second)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			shortTimeoutClient := &http.Client{Timeout: 100 * time.Millisecond}
+
+			resp, err := DoHTTPWithRetry(server.URL, shortTimeoutClient.Get)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(attempt).To(BeNumerically(">=", 2))
+		})
+
+		It("retries on connection refused", func() {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).ToNot(HaveOccurred())
+			addr := listener.Addr().String()
+			listener.Close()
+
+			attempt := 0
+			getFunc := func(url string) (*http.Response, error) {
+				attempt++
+				if attempt <= 2 {
+					return httpClient.Get("http://" + addr)
+				}
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+				return httpClient.Get(server.URL)
+			}
+
+			resp, err := DoHTTPWithRetry("http://"+addr, getFunc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(attempt).To(Equal(3))
+		})
+	})
+
+	Describe("isRetriableNetworkError", func() {
+		It("returns true for context.DeadlineExceeded wrapped in url.Error", func() {
+			err := &url.Error{
+				Op:  "Get",
+				URL: "https://prow.ci.kubevirt.io/pr-history",
+				Err: context.DeadlineExceeded,
+			}
+			Expect(isRetriableNetworkError(err)).To(BeTrue())
+		})
+
+		It("returns true for a dial TCP connection refused error", func() {
+			err := &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Addr: &net.TCPAddr{
+					IP:   net.ParseIP("127.0.0.1"),
+					Port: 8080,
+				},
+				Err: fmt.Errorf("connection refused"),
+			}
+			Expect(isRetriableNetworkError(err)).To(BeTrue())
+		})
+
+		It("returns true for a DNS lookup error", func() {
+			err := &net.DNSError{
+				Err:        "no such host",
+				Name:       "prow.ci.kubevirt.io",
+				IsNotFound: true,
+			}
+			Expect(isRetriableNetworkError(err)).To(BeTrue())
+		})
+
+		It("returns true for an i/o timeout wrapped in net.OpError", func() {
+			err := &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: &timeoutError{msg: "i/o timeout"},
+			}
+			Expect(isRetriableNetworkError(err)).To(BeTrue())
+		})
+
+		It("returns false for nil error", func() {
+			Expect(isRetriableNetworkError(nil)).To(BeFalse())
+		})
+
+		It("returns false for non-network errors", func() {
+			Expect(isRetriableNetworkError(fmt.Errorf("invalid JSON in response"))).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `badges-update` GitHub Action fails intermittently with `dial tcp timeout` errors when fetching prow's pr-history page. The `DoHTTPWithRetry` function marks all network errors as `retry.Unrecoverable`, so they never get retried despite having 5 attempts configured with exponential backoff.
This PR:
- Adds `isRetriableNetworkError()` to classify transient network errors (timeouts, connection refused, DNS failures)
- Updates `DoHTTPWithRetry` to retry on transient network errors instead of aborting immediately
- Adds an `http.Client` with a 90s timeout (previously used `http.DefaultClient` with no timeout)
- Updates `HttpGetWithRetry`/`HttpHeadWithRetry` to use the new client

**Which issue(s) this PR fixes** *
Fixes #175 

**Special notes for your reviewer**:
/cc @dhiller @dollierp 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary network issues during HTTP requests.
  - Requests now retry after timeouts, DNS failures, and connection errors instead of failing immediately.
  - Added a 90-second timeout to outbound HTTP requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->